### PR TITLE
Update various manifests and backport toolchain changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 
 A collection of CUDA releases and requisite packages which have aged out of Nixpkgs.
 
+Support is best-effort. Because the ecosystem moves quickly, I (@ConnorBaker) only build and test against the commit pinned in flake.nix. If you are using a commit older than what is in the flake, you are doing so at your own risk.
+
+We generally use commits from the latest stable release branch; the overlay should work with changes on `master` but, again, do so at your own risk.
+
+Currently, that is (always be sure to verify as the README is not kept in sync):
+
+```nix
+# nixos-25.11 2026-03-24
+nixpkgs = getFlake "github:NixOS/nixpkgs/1073dad219cb244572b74da2b20c7fe39cb3fa9e";
+```
+
 # License
 
 `cuda-legacy` originates as a copy of Nixpkgs and is also licensed under the [MIT License](https://github.com/NixOS/nixpkgs/blob/0274b441515c91f499c5713a40a24e36faeb0134/COPYING).

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,10 @@
       inputs =
         let
           defaults = {
-            nixpkgs = getFlake "github:NixOS/nixpkgs/5475d3690311aad99f05b24bd91ae43be21aa11b";
-            flake-parts = getFlake "github:hercules-ci/flake-parts/2cccadc7357c0ba201788ae99c4dfa90728ef5e0";
+            # nixos-25.11 2026-03-24
+            nixpkgs = getFlake "github:NixOS/nixpkgs/1073dad219cb244572b74da2b20c7fe39cb3fa9e";
+            # main 2026-03-01
+            flake-parts = getFlake "github:hercules-ci/flake-parts/f20dc5d9b8027381c474144ecabc9034d6a839a3";
           };
 
           # If processing self or an input distinct from self, pass it through.

--- a/overlays/cudaPackagesVersions.nix
+++ b/overlays/cudaPackagesVersions.nix
@@ -105,42 +105,42 @@ final: prev: {
       };
 
       cudaPackages_12_0 = mkCudaPackages {
-        cublasmp = "0.8.1";
+        cublasmp = "0.8.0";
         cuda = "12.0.1";
         cudnn = "9.20.0";
         cudss = "0.7.1";
       };
 
       cudaPackages_12_1 = mkCudaPackages {
-        cublasmp = "0.8.1";
+        cublasmp = "0.8.0";
         cuda = "12.1.1";
         cudnn = "9.20.0";
         cudss = "0.7.1";
       };
 
       cudaPackages_12_2 = mkCudaPackages {
-        cublasmp = "0.8.1";
+        cublasmp = "0.8.0";
         cuda = "12.2.2";
         cudnn = "9.20.0";
         cudss = "0.7.1";
       };
 
       cudaPackages_12_3 = mkCudaPackages {
-        cublasmp = "0.8.1";
+        cublasmp = "0.8.0";
         cuda = "12.3.2";
         cudnn = "9.20.0";
         cudss = "0.7.1";
       };
 
       cudaPackages_12_4 = mkCudaPackages {
-        cublasmp = "0.8.1";
+        cublasmp = "0.8.0";
         cuda = "12.4.1";
         cudnn = "9.20.0";
         cudss = "0.7.1";
       };
 
       cudaPackages_12_5 = mkCudaPackages {
-        cublasmp = "0.8.1";
+        cublasmp = "0.8.0";
         cuda = "12.5.1";
         cudnn = "9.20.0";
         cudss = "0.7.1";
@@ -154,19 +154,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.1";
+          cublasmp = "0.8.0";
           cuda = "12.6.3";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "26.01.0";
-          cusolvermp = "0.7.1";
+          cuquantum = "25.09.0";
+          cusolvermp = "0.7.0";
           cusparselt = "0.6.3";
-          cutensor = "2.6.0";
+          cutensor = "2.3.1";
           nppplus = "0.10.0";
-          nvcomp = "5.1.0";
-          nvjpeg2000 = "0.9.1";
-          nvpl = "25.11";
-          nvtiff = "0.6.0";
+          nvcomp = "5.0.0.6";
+          nvjpeg2000 = "0.9.0";
+          nvpl = "25.5";
+          nvtiff = "0.5.1";
           tensorrt =
             if hasJetsonCudaCapability then
               "10.7.0"
@@ -184,19 +184,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.1";
+          cublasmp = "0.8.0";
           cuda = "12.8.1";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "26.01.0";
-          cusolvermp = "0.7.1";
+          cuquantum = "25.09.0";
+          cusolvermp = "0.7.0";
           cusparselt = "0.8.1";
-          cutensor = "2.6.0";
+          cutensor = "2.3.1";
           nppplus = "0.10.0";
-          nvcomp = "5.1.0";
-          nvjpeg2000 = "0.9.1";
-          nvpl = "25.11";
-          nvtiff = "0.6.0";
+          nvcomp = "5.0.0.6";
+          nvjpeg2000 = "0.9.0";
+          nvpl = "25.5";
+          nvtiff = "0.5.1";
           tensorrt =
             if hasJetsonCudaCapability then
               "10.7.0"
@@ -214,19 +214,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.1";
+          cublasmp = "0.8.0";
           cuda = "12.9.1";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "26.01.0";
-          cusolvermp = "0.7.1";
+          cuquantum = "25.09.0";
+          cusolvermp = "0.7.0";
           cusparselt = "0.8.1";
-          cutensor = "2.6.0";
+          cutensor = "2.3.1";
           nppplus = "0.10.0";
-          nvcomp = "5.1.0";
-          nvjpeg2000 = "0.9.1";
-          nvpl = "25.11";
-          nvtiff = "0.6.0";
+          nvcomp = "5.0.0.6";
+          nvjpeg2000 = "0.9.0";
+          nvpl = "25.5";
+          nvtiff = "0.5.1";
           tensorrt =
             if hasJetsonCudaCapability then
               "10.7.0"
@@ -243,19 +243,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.1";
+          cublasmp = "0.8.0";
           cuda = "13.0.2";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "26.01.0";
-          cusolvermp = "0.7.1";
-          cusparselt = "0.9.0";
-          cutensor = "2.6.0";
+          cuquantum = "25.09.0";
+          cusolvermp = "0.7.0";
+          cusparselt = "0.8.1";
+          cutensor = "2.3.1";
           nppplus = "0.10.0";
-          nvcomp = "5.1.0";
-          nvjpeg2000 = "0.9.1";
-          nvpl = "25.11";
-          nvtiff = "0.6.0";
+          nvcomp = "5.0.0.6";
+          nvjpeg2000 = "0.9.0";
+          nvpl = "25.5";
+          nvtiff = "0.5.1";
           tensorrt =
             if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.14.1";
         };
@@ -267,19 +267,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.1";
+          cublasmp = "0.8.0";
           cuda = "13.1.1";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "26.01.0";
-          cusolvermp = "0.7.1";
-          cusparselt = "0.9.0";
-          cutensor = "2.6.0";
+          cuquantum = "25.09.0";
+          cusolvermp = "0.7.0";
+          cusparselt = "0.8.1";
+          cutensor = "2.3.1";
           nppplus = "0.10.0";
-          nvcomp = "5.1.0";
-          nvjpeg2000 = "0.9.1";
-          nvpl = "25.11";
-          nvtiff = "0.6.0";
+          nvcomp = "5.0.0.6";
+          nvjpeg2000 = "0.9.0";
+          nvpl = "25.5";
+          nvtiff = "0.5.1";
           tensorrt =
             if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.14.1";
         };
@@ -291,19 +291,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.1";
+          cublasmp = "0.8.0";
           cuda = "13.2.0";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "26.01.0";
-          cusolvermp = "0.7.1";
-          cusparselt = "0.9.0";
-          cutensor = "2.6.0";
+          cuquantum = "25.09.0";
+          cusolvermp = "0.7.0";
+          cusparselt = "0.8.1";
+          cutensor = "2.3.1";
           nppplus = "0.10.0";
-          nvcomp = "5.1.0";
-          nvjpeg2000 = "0.9.1";
-          nvpl = "25.11";
-          nvtiff = "0.6.0";
+          nvcomp = "5.0.0.6";
+          nvjpeg2000 = "0.9.0";
+          nvpl = "25.5";
+          nvtiff = "0.5.1";
           tensorrt =
             if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.14.1";
         };

--- a/overlays/cudaPackagesVersions.nix
+++ b/overlays/cudaPackagesVersions.nix
@@ -105,42 +105,42 @@ final: prev: {
       };
 
       cudaPackages_12_0 = mkCudaPackages {
-        cublasmp = "0.8.0";
+        cublasmp = "0.8.1";
         cuda = "12.0.1";
         cudnn = "9.20.0";
         cudss = "0.7.1";
       };
 
       cudaPackages_12_1 = mkCudaPackages {
-        cublasmp = "0.8.0";
+        cublasmp = "0.8.1";
         cuda = "12.1.1";
         cudnn = "9.20.0";
         cudss = "0.7.1";
       };
 
       cudaPackages_12_2 = mkCudaPackages {
-        cublasmp = "0.8.0";
+        cublasmp = "0.8.1";
         cuda = "12.2.2";
         cudnn = "9.20.0";
         cudss = "0.7.1";
       };
 
       cudaPackages_12_3 = mkCudaPackages {
-        cublasmp = "0.8.0";
+        cublasmp = "0.8.1";
         cuda = "12.3.2";
         cudnn = "9.20.0";
         cudss = "0.7.1";
       };
 
       cudaPackages_12_4 = mkCudaPackages {
-        cublasmp = "0.8.0";
+        cublasmp = "0.8.1";
         cuda = "12.4.1";
         cudnn = "9.20.0";
         cudss = "0.7.1";
       };
 
       cudaPackages_12_5 = mkCudaPackages {
-        cublasmp = "0.8.0";
+        cublasmp = "0.8.1";
         cuda = "12.5.1";
         cudnn = "9.20.0";
         cudss = "0.7.1";
@@ -154,19 +154,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.0";
+          cublasmp = "0.8.1";
           cuda = "12.6.3";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "25.09.0";
-          cusolvermp = "0.7.0";
+          cuquantum = "26.01.0";
+          cusolvermp = "0.7.1";
           cusparselt = "0.6.3";
-          cutensor = "2.3.1";
+          cutensor = "2.6.0";
           nppplus = "0.10.0";
-          nvcomp = "5.0.0.6";
-          nvjpeg2000 = "0.9.0";
-          nvpl = "25.5";
-          nvtiff = "0.5.1";
+          nvcomp = "5.1.0";
+          nvjpeg2000 = "0.9.1";
+          nvpl = "25.11";
+          nvtiff = "0.6.0";
           tensorrt =
             if hasJetsonCudaCapability then
               "10.7.0"
@@ -184,19 +184,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.0";
+          cublasmp = "0.8.1";
           cuda = "12.8.1";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "25.09.0";
-          cusolvermp = "0.7.0";
+          cuquantum = "26.01.0";
+          cusolvermp = "0.7.1";
           cusparselt = "0.8.1";
-          cutensor = "2.3.1";
+          cutensor = "2.6.0";
           nppplus = "0.10.0";
-          nvcomp = "5.0.0.6";
-          nvjpeg2000 = "0.9.0";
-          nvpl = "25.5";
-          nvtiff = "0.5.1";
+          nvcomp = "5.1.0";
+          nvjpeg2000 = "0.9.1";
+          nvpl = "25.11";
+          nvtiff = "0.6.0";
           tensorrt =
             if hasJetsonCudaCapability then
               "10.7.0"
@@ -214,19 +214,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.0";
+          cublasmp = "0.8.1";
           cuda = "12.9.1";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "25.09.0";
-          cusolvermp = "0.7.0";
+          cuquantum = "26.01.0";
+          cusolvermp = "0.7.1";
           cusparselt = "0.8.1";
-          cutensor = "2.3.1";
+          cutensor = "2.6.0";
           nppplus = "0.10.0";
-          nvcomp = "5.0.0.6";
-          nvjpeg2000 = "0.9.0";
-          nvpl = "25.5";
-          nvtiff = "0.5.1";
+          nvcomp = "5.1.0";
+          nvjpeg2000 = "0.9.1";
+          nvpl = "25.11";
+          nvtiff = "0.6.0";
           tensorrt =
             if hasJetsonCudaCapability then
               "10.7.0"
@@ -243,19 +243,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.0";
+          cublasmp = "0.8.1";
           cuda = "13.0.2";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "25.09.0";
-          cusolvermp = "0.7.0";
-          cusparselt = "0.8.1";
-          cutensor = "2.3.1";
+          cuquantum = "26.01.0";
+          cusolvermp = "0.7.1";
+          cusparselt = "0.9.0";
+          cutensor = "2.6.0";
           nppplus = "0.10.0";
-          nvcomp = "5.0.0.6";
-          nvjpeg2000 = "0.9.0";
-          nvpl = "25.5";
-          nvtiff = "0.5.1";
+          nvcomp = "5.1.0";
+          nvjpeg2000 = "0.9.1";
+          nvpl = "25.11";
+          nvtiff = "0.6.0";
           tensorrt =
             if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.14.1";
         };
@@ -267,19 +267,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.0";
+          cublasmp = "0.8.1";
           cuda = "13.1.1";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "25.09.0";
-          cusolvermp = "0.7.0";
-          cusparselt = "0.8.1";
-          cutensor = "2.3.1";
+          cuquantum = "26.01.0";
+          cusolvermp = "0.7.1";
+          cusparselt = "0.9.0";
+          cutensor = "2.6.0";
           nppplus = "0.10.0";
-          nvcomp = "5.0.0.6";
-          nvjpeg2000 = "0.9.0";
-          nvpl = "25.5";
-          nvtiff = "0.5.1";
+          nvcomp = "5.1.0";
+          nvjpeg2000 = "0.9.1";
+          nvpl = "25.11";
+          nvtiff = "0.6.0";
           tensorrt =
             if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.14.1";
         };
@@ -291,19 +291,19 @@ final: prev: {
             ;
         in
         mkCudaPackages {
-          cublasmp = "0.8.0";
+          cublasmp = "0.8.1";
           cuda = "13.2.0";
           cudnn = "9.20.0";
           cudss = "0.7.1";
-          cuquantum = "25.09.0";
-          cusolvermp = "0.7.0";
-          cusparselt = "0.8.1";
-          cutensor = "2.3.1";
+          cuquantum = "26.01.0";
+          cusolvermp = "0.7.1";
+          cusparselt = "0.9.0";
+          cutensor = "2.6.0";
           nppplus = "0.10.0";
-          nvcomp = "5.0.0.6";
-          nvjpeg2000 = "0.9.0";
-          nvpl = "25.5";
-          nvtiff = "0.5.1";
+          nvcomp = "5.1.0";
+          nvjpeg2000 = "0.9.1";
+          nvpl = "25.11";
+          nvtiff = "0.6.0";
           tensorrt =
             if hasPreThorJetsonCudaCapability requestedJetsonCudaCapabilities then "10.7.0" else "10.14.1";
         };

--- a/overlays/gccVersions.nix
+++ b/overlays/gccVersions.nix
@@ -11,9 +11,11 @@ let
   # gccVersions if they depended on top-level.
   gccVersions = import ../pkgs/development/compilers/gcc/all.nix {
     inherit (final)
+      buildPackages
       callPackage
       isl_0_20
       lib
+      overrideCC
       pkgs
       stdenv
       targetPackages

--- a/pkgs/development/compilers/gcc/README.md
+++ b/pkgs/development/compilers/gcc/README.md
@@ -41,7 +41,7 @@ changes:
   `disableBootstrap` guards, Darwin `cc` vs `c` file extension, hash format
   selection).
 - **`patches/default.nix`**: Retains the full three-tier patch structure
-  (all-platform, platform-specific, gcc<12-only) including patches for GCC 9-12
+  (all-platform, platform-specific, gcc\<12-only) including patches for GCC 9-12
   on Darwin, MinGW, musl, etc.
 - **`common/dependencies.nix`**: Conditionalizes `libxcrypt` on GCC >= 10.
 - **`common/configure-flags.nix`**: Retains `--disable-libsanitizer` for

--- a/pkgs/development/compilers/gcc/README.md
+++ b/pkgs/development/compilers/gcc/README.md
@@ -1,0 +1,195 @@
+# Vendored GCC Compilers
+
+This directory contains GCC compiler expressions vendored from
+[Nixpkgs](https://github.com/NixOS/nixpkgs). We maintain them here because
+older CUDA toolkit versions (11.x) require GCC versions (9-12) that have been
+removed from upstream Nixpkgs.
+
+## Origin
+
+The GCC subtree was originally extracted from Nixpkgs using `git filter-branch`
+(preserving full upstream commit history for `pkgs/development/compilers/gcc/`).
+
+| Milestone | Nixpkgs commit | Date |
+|-----------|---------------|------|
+| Initial vendoring | `bf0d1707ba1e12471a0b554013187e0c5b74f779` | 2025-04-01 |
+| Fast-forward update | `231cae33e7f7d667d9455b026cbb5fd8b9307763` | 2025-10-20 |
+| Latest upstream sync | `1b82c5f564a0e07c87f28e8be9776e45723f58f5` | 2026-03-21 |
+
+Dates reflect when the Nixpkgs commit was merged, not its author date.
+
+The fast-forward update (commit `1e6fa6b` in this repo) explicitly reverted four
+upstream commits that dropped GCC 9-12:
+
+- `f3186c59` {gcc12,gfortran12,gccgo12,gnat12,gnat-bootstrap12}: drop
+- `10ce2b47` {gcc11,gfortran11,gdc11,gnat11,gnat-bootstrap11}: drop
+- `4e7ee62b` {gcc10,gfortran10}: drop
+- `2a196a72` {gcc9,gfortran9}: drop
+
+## Local modifications
+
+Beyond re-adding the dropped GCC versions, we carry a small number of local
+changes:
+
+- **`all.nix`**: The function takes single-component major versions (`"9"`,
+  `"10"`, ...) instead of two-component versions. Returns `{ name; value; }`
+  attribute sets instead of using `lib.nameValuePair`. Uses
+  `builtins.listToAttrs` instead of `lib.listToAttrs`.
+- **`versions.nix`**: Retains version entries and source hashes for GCC 9-12.
+- **`default.nix`**: Retains version predicates (`atLeast10`, `atLeast11`,
+  `is9`, `is10`, etc.) and conditional logic for older GCC versions (e.g.,
+  `disableBootstrap` guards, Darwin `cc` vs `c` file extension, hash format
+  selection).
+- **`patches/default.nix`**: Retains the full three-tier patch structure
+  (all-platform, platform-specific, gcc<12-only) including patches for GCC 9-12
+  on Darwin, MinGW, musl, etc.
+- **`common/dependencies.nix`**: Conditionalizes `libxcrypt` on GCC >= 10.
+- **`common/configure-flags.nix`**: Retains `--disable-libsanitizer` for
+  mips64+glibc on GCC 12.
+- **`common/libgcc.nix`**: `enableLibGccOutput` uses an `or` fallback for
+  `isPE` (see "Compatibility with release branches" below).
+
+We also carry 17 extra patch files for GCC 9-12 that upstream no longer ships
+(mcf-thread-model backports, `no-sys-dirs` variants, gnat/gfortran fixes, etc.).
+
+## How to sync with upstream
+
+When Nixpkgs makes changes to `pkgs/development/compilers/gcc/`, we port them
+here to stay current. The process:
+
+### 1. Identify new upstream commits
+
+```bash
+# The commit recorded in "Latest upstream sync" above
+LAST_SYNC=1b82c5f564a0e07c87f28e8be9776e45723f58f5
+
+git -C /path/to/nixpkgs log --no-merges --format="%h %ai %s" \
+  $LAST_SYNC..HEAD -- pkgs/development/compilers/gcc/
+```
+
+### 2. Check branch applicability
+
+This overlay must work against both `master` and the current stable release
+branch (e.g., `release-25.11`). For each upstream commit, check which branches
+contain it:
+
+```bash
+git -C /path/to/nixpkgs merge-base --is-ancestor <commit> release-25.11 \
+  && echo "on 25.11" || echo "master only"
+```
+
+Our preference is to apply changes unconditionally where possible. Most upstream
+GCC changes are safe to include even if they haven't been backported to the
+release branch (e.g., a glibc 2.42 compatibility patch is harmless on a glibc
+2.40 system).
+
+### 3. Generate patches
+
+```bash
+git -C /path/to/nixpkgs format-patch -1 <commit> -o /path/to/patches/
+```
+
+Generate one patch per commit. Commits that are part of treewide changes will
+include hunks for files outside the GCC tree; these are filtered at apply time.
+
+### 4. Apply with authorship preserved
+
+```bash
+git am -3 --include='pkgs/development/compilers/gcc/*' /path/to/patches/*.patch
+```
+
+- `--include` strips non-GCC hunks from treewide patches.
+- `-3` enables 3-way merge for better conflict resolution.
+
+When `-3` fails (typically for treewide commits where the base tree differs),
+fall back to:
+
+```bash
+git apply --include='pkgs/development/compilers/gcc/*' -C0 <patch>
+```
+
+Then commit manually with the original author metadata:
+
+```bash
+GIT_AUTHOR_NAME="..." GIT_AUTHOR_EMAIL="..." GIT_AUTHOR_DATE="..." \
+  git commit -m "<original subject>"
+```
+
+The author name, email, and date are in the `From:` and `Date:` headers of the
+generated patch file.
+
+### 5. Handle compatibility with release branches
+
+Upstream changes may use Nixpkgs library functions or platform attributes that
+only exist on `master` and have not been backported to the release branch. Since
+our overlay must work against both, use the Nix `or` keyword to provide
+fallbacks:
+
+```nix
+# Attribute that may not exist on older Nixpkgs:
+stdenv.hostPlatform.isPE or (stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isCygwin)
+
+# Team that may not exist:
+lib.optionals (teams ? security-review) [ teams.security-review ]
+
+# Lib function that may not exist (check with `?` or provide inline equivalent):
+lib.meta.cpeFullVersionWithVendor or (vendor: version: { inherit vendor version; })
+```
+
+Known examples from the current sync:
+
+- `isPE` — added in Nixpkgs `3dcf921c` (master only). Equivalent to
+  `isWindows || isCygwin`.
+- `teams.security-review` — added to Nixpkgs after the current pin and not on
+  `release-25.11`.
+- `lib.meta.cpeFullVersionWithVendor` — exists on both branches currently, but
+  worth checking when the release branch changes.
+
+### 6. Evaluate whether changes should extend to older compilers
+
+Upstream only ships GCC 13+, so their patches are version-guarded accordingly.
+When porting, evaluate whether each change should also cover GCC 9-12:
+
+- **Shared infrastructure** (`default.nix`, `common/*.nix`, `builder.nix`):
+  changes here affect all versions automatically. No action needed.
+- **`patches/default.nix`**: if upstream adds a patch for GCC 13/14, check
+  whether the same bug exists in GCC 9-12. The patch file itself may not apply
+  cleanly to older sources (different line numbers), so version-specific patches
+  or configure flags (e.g., `--disable-libsanitizer`) may be needed.
+- **`ng/`**: the next-gen split package set only targets GCC 15+. Changes there
+  don't affect older compilers.
+
+### 7. Verify evaluation
+
+After all patches are applied, verify that every GCC version evaluates:
+
+```bash
+for v in 9 10 11 12 13 14 15; do
+  echo -n "gcc$v: "
+  nix eval .#legacyPackages.x86_64-linux.gccVersions.gcc$v.version
+done
+```
+
+Evaluation failures typically indicate missing attributes in the Nixpkgs pin
+(see step 5).
+
+### 8. Resolve conflicts
+
+Most conflicts occur in `patches/default.nix` because our file has ~130 extra
+lines for GCC 9-12 patches that upstream doesn't have. The upstream patches
+target different line numbers, but the actual changes are typically small
+(adding a new `++ optional ...` line or a new patch file). Apply the upstream
+intent to the corresponding location in our expanded file.
+
+Conflicts in `all.nix` arise because we restructured the function signature.
+Adapt upstream's changes to our function shape.
+
+### 9. Update the overlay if needed
+
+If upstream adds new arguments to `all.nix` or `default.nix`, update
+`overlays/gccVersions.nix` to pass them through from the overlay's `final`.
+
+### 10. Update this README
+
+After syncing, update the "Latest upstream sync" row in the table above with
+the hash and date of the newest upstream commit incorporated.

--- a/pkgs/development/compilers/gcc/all.nix
+++ b/pkgs/development/compilers/gcc/all.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   pkgs,
+  overrideCC,
+  buildPackages,
   targetPackages,
   callPackage,
   isl_0_20,
@@ -60,7 +62,7 @@ let
                 )
                 && stdenv.cc.isGNU
               then
-                pkgs."gcc${majorVersion}Stdenv"
+                overrideCC stdenv buildPackages."gcc${majorVersion}"
               else
                 stdenv;
           }

--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -363,6 +363,13 @@ originalAttrs:
           fi
       done
     ''
+    + lib.optionalString stdenv.targetPlatform.isCygwin ''
+      targetBinDir="''${targetConfig+$targetConfig/}bin"
+      for i in "''${!outputBin}/$targetLibDir"/cyg*.dll; do
+        mkdir -p "''${!outputLib}/$targetBinDir"
+        mv "$i" "''${!outputLib}/$targetBinDir"/
+      done
+    ''
     # if cross-compiling, link from $lib/lib to $lib/${targetConfig}.
     # since native-compiles have $lib/lib as a directory (not a
     # symlink), this ensures that in every case we can assume that

--- a/pkgs/development/compilers/gcc/common/dependencies.nix
+++ b/pkgs/development/compilers/gcc/common/dependencies.nix
@@ -7,6 +7,7 @@
   texinfo,
   which,
   gettext,
+  autoconf269,
   gnused,
   patchelf,
   gmp,
@@ -41,6 +42,7 @@ in
     texinfo
     which
     gettext
+    autoconf269
   ]
   ++ optionals (perl != null) [ perl ]
   ++ optionals (with stdenv.targetPlatform; isVc4 || isRedox || isSnapshot && flex != null) [ flex ]

--- a/pkgs/development/compilers/gcc/common/libgcc.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc.nix
@@ -63,7 +63,9 @@ lib.pipe drv
               # $libgcc logic is currently hardcoded for .so
               # NOTE: isPE was added in Nixpkgs 3dcf921c (master only, not release-25.11).
               !(stdenv.hostPlatform.isPE or (stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isCygwin))
-              && !(stdenv.targetPlatform.isPE or (stdenv.targetPlatform.isWindows || stdenv.targetPlatform.isCygwin))
+              && !(stdenv.targetPlatform.isPE
+                or (stdenv.targetPlatform.isWindows || stdenv.targetPlatform.isCygwin)
+              )
               && !langJit
               && !stdenv.hostPlatform.isDarwin
               && enableShared

--- a/pkgs/development/compilers/gcc/common/libgcc.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc.nix
@@ -60,7 +60,9 @@ lib.pipe drv
             useLibgccFromTargetLibc = libcCross != null && libcCross ? passthru.libgcc;
 
             enableLibGccOutput =
-              (!stdenv.targetPlatform.isWindows || (lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform))
+              # $libgcc logic is currently hardcoded for .so
+              !stdenv.hostPlatform.isPE
+              && !stdenv.targetPlatform.isPE
               && !langJit
               && !stdenv.hostPlatform.isDarwin
               && enableShared

--- a/pkgs/development/compilers/gcc/common/libgcc.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc.nix
@@ -61,8 +61,9 @@ lib.pipe drv
 
             enableLibGccOutput =
               # $libgcc logic is currently hardcoded for .so
-              !stdenv.hostPlatform.isPE
-              && !stdenv.targetPlatform.isPE
+              # NOTE: isPE was added in Nixpkgs 3dcf921c (master only, not release-25.11).
+              !(stdenv.hostPlatform.isPE or (stdenv.hostPlatform.isWindows || stdenv.hostPlatform.isCygwin))
+              && !(stdenv.targetPlatform.isPE or (stdenv.targetPlatform.isWindows || stdenv.targetPlatform.isCygwin))
               && !langJit
               && !stdenv.hostPlatform.isDarwin
               && enableShared

--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -30,5 +30,5 @@ in
   teams = [ teams.gcc ];
   mainProgram = "${targetPrefix}gcc";
 
-  identifiers.cpeParts.vendor = "gnu";
+  identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version;
 }

--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -27,7 +27,10 @@ in
   '';
 
   platforms = platforms.unix;
-  teams = [ teams.gcc ];
+  teams = [
+    teams.gcc
+    teams.security-review
+  ];
   mainProgram = "${targetPrefix}gcc";
 
   identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version;

--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -29,7 +29,8 @@ in
   platforms = platforms.unix;
   teams = [
     teams.gcc
-  ] ++ lib.optionals (teams ? security-review) [
+  ]
+  ++ lib.optionals (teams ? security-review) [
     teams.security-review
   ];
   mainProgram = "${targetPrefix}gcc";

--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -29,6 +29,7 @@ in
   platforms = platforms.unix;
   teams = [
     teams.gcc
+  ] ++ lib.optionals (teams ? security-review) [
     teams.security-review
   ];
   mainProgram = "${targetPrefix}gcc";

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -80,6 +80,19 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
       export inhibit_libc=true
     ''
 
+# We need to reconfigure the build system in case it has been patched. Since
+# gcc is patched quite often, reconfiguring it unconditionally makes sense.
+# This is also good practice for a couple other reasons.
+# See <https://wiki.debian.org/Autoreconf>.
++ ''
+  for i in */configure.ac; do
+    pushd "$(dirname "$i")"
+    echo "Running autoreconf in $PWD"
+    autoconf -f
+    popd
+  done
+''
+
 + lib.optionalString (
   (!lib.systems.equals targetPlatform hostPlatform) && withoutTargetLibc && enableShared
 ) (import ./libgcc-buildstuff.nix { inherit lib stdenv; })

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -19,7 +19,7 @@
   cargo,
   staticCompiler ? false,
   enableShared ? stdenv.targetPlatform.hasSharedLibraries,
-  enableDefaultPie ? true,
+  enableDefaultPie ? stdenv.targetPlatform.hasSharedLibraries,
   enableLTO ? stdenv.hostPlatform.hasSharedLibraries,
   texinfo ? null,
   perl ? null, # optional, for texi2pod (then pod2man)

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -243,7 +243,6 @@ pipe
 
       hardeningDisable = [
         "format"
-        "pie"
         "stackclashprotection"
       ]
       ++ optionals (is11 && langAda) [ "fortify3" ];

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -30,6 +30,7 @@
   which,
   patchelf,
   binutils,
+  autoconf269,
   isl ? null, # optional, for the Graphite optimization framework.
   zlib ? null,
   libucontext ? null,
@@ -140,6 +141,7 @@ let
     # inherit generated with 'nix eval --json --impure --expr "with import ./. {}; lib.attrNames (lib.functionArgs gcc${majorVersion}.cc.override)" | jq '.[]' --raw-output'
     inherit
       apple-sdk
+      autoconf269
       binutils
       buildPackages
       cargo

--- a/pkgs/development/compilers/gcc/ng/15/libatomic/gthr-include.patch
+++ b/pkgs/development/compilers/gcc/ng/15/libatomic/gthr-include.patch
@@ -1,0 +1,16 @@
+This change was upstreamed in e5d853bbe9b05d6a00d98ad236f01937303e40c4
+in GCC, but this file was slightly different in GCC 15, so we're
+patching it manually.
+
+diff --git a/libatomic/aclocal.m4 b/libatomic/aclocal.m4
+index 80e24219d7d..581fedcfe13 100644
+--- a/libatomic/aclocal.m4
++++ b/libatomic/aclocal.m4
+@@ -1189,6 +1189,7 @@ AC_SUBST([am__untar])
+
+ m4_include([../config/acx.m4])
+ m4_include([../config/depstand.m4])
++m4_include([../config/gthr.m4])
+ m4_include([../config/lead-dot.m4])
+ m4_include([../config/lthostflags.m4])
+ m4_include([../config/multi.m4])

--- a/pkgs/development/compilers/gcc/ng/common/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/default.nix
@@ -130,6 +130,7 @@ makeScopeWithSplicing' {
           "-B${targetGccPackages.libgcc}/lib"
           "-B${targetGccPackages.libssp}/lib"
           "-B${targetGccPackages.libatomic}/lib"
+          "-B${targetGccPackages.libgomp}/lib"
           "-B${targetGccPackages.libgfortran}/lib/"
         ];
       };
@@ -145,6 +146,8 @@ makeScopeWithSplicing' {
           "-B${targetGccPackages.libgcc}/lib"
           "-B${targetGccPackages.libssp}/lib"
           "-B${targetGccPackages.libatomic}/lib"
+          "-B${targetGccPackages.libgomp}/lib"
+          "-I${targetGccPackages.libgomp}/lib/gcc/${metadata.release_version}/include"
         ];
       };
 
@@ -159,6 +162,8 @@ makeScopeWithSplicing' {
           "-B${targetGccPackages.libgcc}/lib"
           "-B${targetGccPackages.libssp}/lib"
           "-B${targetGccPackages.libatomic}/lib"
+          "-B${targetGccPackages.libgomp}/lib"
+          "-I${targetGccPackages.libgomp}/lib/gcc/${metadata.release_version}/include"
         ];
       };
 
@@ -229,6 +234,10 @@ makeScopeWithSplicing' {
       };
 
       libstdcxx = callPackage ./libstdcxx {
+        stdenv = overrideCC stdenv buildGccPackages.gccWithLibatomic;
+      };
+
+      libgomp = callPackage ./libgomp {
         stdenv = overrideCC stdenv buildGccPackages.gccWithLibatomic;
       };
     };

--- a/pkgs/development/compilers/gcc/ng/common/libatomic/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libatomic/default.nix
@@ -41,13 +41,14 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (fetchpatch {
       name = "custom-threading-model.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250716204545.1063669-1-git@JohnEricson.me/raw";
-      hash = "sha256-kxNntY2r4i/+XHQSpf9bYV2Jg+FD/pD5TiMn5hd4ckk=";
+      url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
+      hash = "sha256-U1Eh6ByhmseHQigfHIyO4MlAQB3fECmpPEP/M00DOg0=";
       includes = [
         "config/*"
-        "libatomic/*"
+        "libatomic/configure.ac"
       ];
     })
+    (getVersionFile "libatomic/gthr-include.patch")
   ];
 
   postUnpack = ''

--- a/pkgs/development/compilers/gcc/ng/common/libbacktrace/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libbacktrace/default.nix
@@ -47,6 +47,11 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir ../../build
     cd ../../build
     configureScript=../$sourceRoot/configure
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # GNU debuglink is not supported on macOS (Mach-O format)
+    # Skip the gnudebuglink tests which fail on Darwin
+    export libbacktrace_cv_objcopy_debuglink=no
   '';
 
   installPhase = ''

--- a/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgcc/default.nix
@@ -45,18 +45,28 @@ stdenv.mkDerivation (finalAttrs: {
     })
     (fetchpatch {
       name = "custom-threading-model.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250716204545.1063669-1-git@JohnEricson.me/raw";
-      hash = "sha256-NgiC4cFeFInXXg27me1XpSeImPaL0WHs50Tf1YHz4ps=";
+      url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
+      hash = "sha256-92LIttIXdh12/lRhivb2JTPpqUmGBRn+uKmR5pzuveo=";
+      includes = [
+        "config/*"
+        "libgcc/configure.ac"
+      ];
     })
     (fetchpatch {
-      name = "libgcc.mvars-less-0.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250716234028.1153560-1-John.Ericson@Obsidian.Systems/raw";
-      hash = "sha256-NEcieDCsy+7IRU3qQKVD3i57OuwGZKB/rmNF8X2I1n0=";
+      name = "no-pie-cflags.patch";
+      url = "https://github.com/gcc-mirror/gcc/commit/77144dd3b6736e0166156bb509590d924375a4f1.diff";
+      hash = "sha256-QlxlTkWAK1dB7JiU5wz2iOW24gj3bFaeBpwb90oWwns=";
+      includes = [
+        "gcc/Makefile.in"
+        "gcc/configure.ac"
+        "libgcc/Makefile.in"
+        "libgcc/configure.ac"
+      ];
     })
     (fetchpatch {
-      name = "libgcc.mvars-less-1.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250716234028.1153560-2-John.Ericson@Obsidian.Systems/raw";
-      hash = "sha256-nfRC4f6m3kHDro4+6E4y1ZPs+prxBQmn0H2rzIjaMWM=";
+      name = "no-target-system-root.patch";
+      url = "https://github.com/gcc-mirror/gcc/commit/9947930b7ae923010c5061fd8fa6b1ec4f22f161.diff";
+      hash = "sha256-BZmpHpJuuyDmQMwpQhSgCZO0Rg7kXt8rTiJAT+e0sUw=";
     })
     (fetchpatch {
       name = "regular-libdir-includedir.patch";

--- a/pkgs/development/compilers/gcc/ng/common/libgomp/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libgomp/default.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  stdenv,
+  gcc_meta,
+  release_version,
+  version,
+  getVersionFile,
+  monorepoSrc ? null,
+  autoreconfHook269,
+  runCommand,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libgomp";
+  inherit version;
+
+  src = runCommand "libgomp-src-${version}" { src = monorepoSrc; } ''
+    runPhase unpackPhase
+
+    mkdir -p "$out/gcc"
+    cp gcc/BASE-VER "$out/gcc"
+    cp gcc/DATESTAMP "$out/gcc"
+
+    cp -r libgomp "$out"
+    cp -r include "$out"
+
+    cp -r config "$out"
+    cp -r multilib.am "$out"
+    cp -r libtool.m4 "$out"
+
+    cp config.guess "$out"
+    cp config.rpath "$out"
+    cp config.sub "$out"
+    cp config-ml.in "$out"
+    cp ltmain.sh "$out"
+    cp install-sh "$out"
+    cp mkinstalldirs "$out"
+
+    [[ -f MD5SUMS ]]; cp MD5SUMS "$out"
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  postUnpack = ''
+    mkdir -p ./build
+    buildRoot=$(readlink -e "./build")
+  '';
+
+  preAutoreconf = ''
+    sourceRoot=$(readlink -e "./libgomp")
+    cd $sourceRoot
+  '';
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    autoreconfHook269
+  ];
+
+  configurePlatforms = [
+    "build"
+    "host"
+  ];
+
+  configureFlags = [
+    "--disable-dependency-tracking"
+    "cross_compiling=true"
+    "--disable-multilib"
+  ];
+
+  preConfigure = ''
+    cd "$buildRoot"
+    configureScript=$sourceRoot/configure
+  '';
+
+  doCheck = true;
+
+  passthru = {
+    isGNU = true;
+  };
+
+  meta = gcc_meta // {
+    homepage = "https://gcc.gnu.org/";
+  };
+})

--- a/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/libstdcxx/default.nix
@@ -54,11 +54,11 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     (fetchpatch {
       name = "custom-threading-model.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250716204545.1063669-1-git@JohnEricson.me/raw";
-      hash = "sha256-jPP0+MoPLtCwWcW6doO6KHCppwAYK40qNVyriLXcGOg=";
+      url = "https://github.com/gcc-mirror/gcc/commit/e5d853bbe9b05d6a00d98ad236f01937303e40c4.diff";
+      hash = "sha256-f0XAim3uzHnUx5lm/xO00IqBHu4YUEHF2WY+c0yCF6Y=";
       includes = [
         "config/*"
-        "libstdc++-v3/*"
+        "libstdc++-v3/acinclude.m4"
       ];
     })
     (getVersionFile "libstdcxx/force-regular-dirs.patch")

--- a/pkgs/development/compilers/gcc/ng/default.nix
+++ b/pkgs/development/compilers/gcc/ng/default.nix
@@ -3,7 +3,6 @@
   callPackage,
   stdenv,
   stdenvAdapters,
-  recurseIntoAttrs,
   gccVersions ? { },
   patchesFn ? lib.id,
   buildPackages,
@@ -44,7 +43,7 @@ let
         args.name or (if (gitRelease != null) then "git" else lib.versions.major release_version);
     in
     lib.nameValuePair attrName (
-      recurseIntoAttrs (
+      lib.recurseIntoAttrs (
         callPackage ./common (
           {
             inherit (stdenvAdapters) overrideCC;

--- a/pkgs/development/compilers/gcc/ng/default.nix
+++ b/pkgs/development/compilers/gcc/ng/default.nix
@@ -14,7 +14,7 @@
 }@packageSetArgs:
 let
   versions = {
-    "15.1.0".officialRelease.sha256 = "sha256-4rCewhZg8B/s/7cV4BICZSFpQ/A40OSKmGhxPlTwbOo=";
+    "15.2.0".officialRelease.sha256 = "sha256-Q4/ZloJrDIJIWinaA6ctcdbjVBqD7HAt9Ccfb+Al0k4=";
   }
   // gccVersions;
 

--- a/pkgs/development/compilers/gcc/patches/13/libsanitizer-fix-with-glibc-2.42.patch
+++ b/pkgs/development/compilers/gcc/patches/13/libsanitizer-fix-with-glibc-2.42.patch
@@ -1,0 +1,74 @@
+From 1789c57dc97ea2f9819ef89e28bf17208b6208e7 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Fri, 2 May 2025 17:41:43 +0200
+Subject: [PATCH] libsanitizer: Fix build with glibc 2.42
+
+The termio structure will be removed from glibc 2.42.  It has
+been deprecated since the late 80s/early 90s.
+
+Cherry-picked from LLVM commit 59978b21ad9c65276ee8e14f26759691b8a65763
+("[sanitizer_common] Remove interceptors for deprecated struct termio
+(#137403)").
+
+Co-Authored-By: Tom Stellard <tstellar@redhat.com>
+
+libsanitizer/
+
+	* sanitizer_common/sanitizer_common_interceptors_ioctl.inc: Cherry
+	picked from LLVM commit 59978b21ad9c65276ee8e14f26759691b8a65763.
+	* sanitizer_common/sanitizer_platform_limits_posix.cpp: Likewise.
+	* sanitizer_common/sanitizer_platform_limits_posix.h: Likewise.
+---
+ .../sanitizer_common_interceptors_ioctl.inc               | 8 --------
+ .../sanitizer_common/sanitizer_platform_limits_posix.cpp  | 3 ---
+ .../sanitizer_common/sanitizer_platform_limits_posix.h    | 1 -
+ 3 files changed, 12 deletions(-)
+
+diff --git a/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc b/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+index 49ec4097c900b..dda11daa77f49 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
++++ b/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+@@ -338,17 +338,9 @@ static void ioctl_table_fill() {
+   _(SOUND_PCM_WRITE_CHANNELS, WRITE, sizeof(int));
+   _(SOUND_PCM_WRITE_FILTER, WRITE, sizeof(int));
+   _(TCFLSH, NONE, 0);
+-#if SANITIZER_GLIBC
+-  _(TCGETA, WRITE, struct_termio_sz);
+-#endif
+   _(TCGETS, WRITE, struct_termios_sz);
+   _(TCSBRK, NONE, 0);
+   _(TCSBRKP, NONE, 0);
+-#if SANITIZER_GLIBC
+-  _(TCSETA, READ, struct_termio_sz);
+-  _(TCSETAF, READ, struct_termio_sz);
+-  _(TCSETAW, READ, struct_termio_sz);
+-#endif
+   _(TCSETS, READ, struct_termios_sz);
+   _(TCSETSF, READ, struct_termios_sz);
+   _(TCSETSW, READ, struct_termios_sz);
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index c87d5ef42c924..7bbc6f2edac2e 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -485,9 +485,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned struct_input_id_sz = sizeof(struct input_id);
+   unsigned struct_mtpos_sz = sizeof(struct mtpos);
+   unsigned struct_rtentry_sz = sizeof(struct rtentry);
+-#if SANITIZER_GLIBC || SANITIZER_ANDROID
+-  unsigned struct_termio_sz = sizeof(struct termio);
+-#endif
+   unsigned struct_vt_consize_sz = sizeof(struct vt_consize);
+   unsigned struct_vt_sizes_sz = sizeof(struct vt_sizes);
+   unsigned struct_vt_stat_sz = sizeof(struct vt_stat);
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+index c07f7cd0b0d08..a80df656826ee 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -1029,7 +1029,6 @@ extern unsigned struct_hd_geometry_sz;
+ extern unsigned struct_input_absinfo_sz;
+ extern unsigned struct_input_id_sz;
+ extern unsigned struct_mtpos_sz;
+-extern unsigned struct_termio_sz;
+ extern unsigned struct_vt_consize_sz;
+ extern unsigned struct_vt_sizes_sz;
+ extern unsigned struct_vt_stat_sz;

--- a/pkgs/development/compilers/gcc/patches/15/aarch64-sve-rtx.patch
+++ b/pkgs/development/compilers/gcc/patches/15/aarch64-sve-rtx.patch
@@ -1,0 +1,87 @@
+Without the change `libhwy-1.3.0` ICEs when built for aarch64-linux as:
+https://github.com/NixOS/nixpkgs/pull/320616#issuecomment-3764400891
+
+Upstream report: http://gcc.gnu.org/PR120718
+Upstream fix: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=d755aa03db0ad5b71ee7f39b09c92870789f2f00
+Fetched as:
+$ curl -L 'https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff_plain;h=d755aa03db0ad5b71ee7f39b09c92870789f2f00' > aarch64-sve-rtx.patch
+
+From: Richard Sandiford <richard.sandiford@arm.com>
+Date: Thu, 14 Aug 2025 16:56:50 +0000 (+0100)
+Subject: Remove MODE_COMPOSITE_P test from simplify_gen_subreg [PR120718]
+X-Git-Url: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff_plain;h=d755aa03db0ad5b71ee7f39b09c92870789f2f00
+
+Remove MODE_COMPOSITE_P test from simplify_gen_subreg [PR120718]
+
+simplify_gen_subreg rejected subregs of literal constants if
+MODE_COMPOSITE_P.  This was added by the fix for PR96648 in
+g:c0f772894b6b3cd8ed5c5dd09d0c7917f51cf70f.  Jakub said:
+
+  As for the simplify_gen_subreg change, I think it would be desirable
+  to just avoid creating SUBREGs of constants on all targets and for all
+  constants, if simplify_immed_subreg simplified, fine, otherwise punt,
+  but as we are late in GCC11 development, the patch instead guards this
+  behavior on MODE_COMPOSITE_P (outermode) - i.e. only conversions to
+  powerpc{,64,64le} double double long double - and only for the cases where
+  simplify_immed_subreg was called.
+
+I'm not sure about relaxing the codes further, since subregs might
+be wanted for CONST, SYMBOL_REF and LABEL_REF.  But removing the
+MODE_COMPOSITE_P is needed to fix PR120718, where we get an ICE
+from generating a subreg of a V2SI const_vector.
+
+Unlike the trunk version, this backport does not remove the
+VOIDmode test; see PR121501.
+
+gcc/
+	PR rtl-optimization/120718
+	* simplify-rtx.cc (simplify_context::simplify_gen_subreg):
+	Remove MODE_COMPOSITE_P condition.
+
+gcc/testsuite/
+	PR rtl-optimization/120718
+	* gcc.target/aarch64/sve/acle/general/pr120718.c: New test.
+---
+
+diff --git a/gcc/simplify-rtx.cc b/gcc/simplify-rtx.cc
+index 88d31a71c05a..8d4cbf1371a3 100644
+--- a/gcc/simplify-rtx.cc
++++ b/gcc/simplify-rtx.cc
+@@ -8317,14 +8317,11 @@ simplify_context::simplify_gen_subreg (machine_mode outermode, rtx op,
+ 
+   if (GET_CODE (op) == SUBREG
+       || GET_CODE (op) == CONCAT
+-      || GET_MODE (op) == VOIDmode)
+-    return NULL_RTX;
+-
+-  if (MODE_COMPOSITE_P (outermode)
+-      && (CONST_SCALAR_INT_P (op)
+-	  || CONST_DOUBLE_AS_FLOAT_P (op)
+-	  || CONST_FIXED_P (op)
+-	  || GET_CODE (op) == CONST_VECTOR))
++      || GET_MODE (op) == VOIDmode
++      || CONST_SCALAR_INT_P (op)
++      || CONST_DOUBLE_AS_FLOAT_P (op)
++      || CONST_FIXED_P (op)
++      || GET_CODE (op) == CONST_VECTOR)
+     return NULL_RTX;
+ 
+   if (validate_subreg (outermode, innermode, op, byte))
+diff --git a/gcc/testsuite/gcc.target/aarch64/sve/acle/general/pr120718.c b/gcc/testsuite/gcc.target/aarch64/sve/acle/general/pr120718.c
+new file mode 100644
+index 000000000000..9ca0938e36bf
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/aarch64/sve/acle/general/pr120718.c
+@@ -0,0 +1,12 @@
++/* { dg-options "-O2" } */
++
++#include <arm_sve.h>
++typedef int __attribute__((vector_size(8))) v2si;
++typedef struct { int x; int y; } A;
++void bar(A a);
++void foo()
++{
++    A a;
++    *(v2si *)&a = (v2si){0, (int)svcntd_pat(SV_ALL)};
++    bar(a);
++}

--- a/pkgs/development/compilers/gcc/patches/15/libgcc-darwin-detection.patch
+++ b/pkgs/development/compilers/gcc/patches/15/libgcc-darwin-detection.patch
@@ -1,11 +1,12 @@
 --- a/libgcc/config.host
 +++ b/libgcc/config.host
-@@ -239,7 +239,7 @@ case ${host} in
+@@ -239,8 +239,8 @@ case ${host} in
      x86_64-*-darwin2[0-2]*)
        tmake_file="t-darwin-min-11 t-darwin-libgccs1 $tmake_file"
        ;;
 -    *-*-darwin2*)
+-      tmake_file="t-darwin-min-11 $tmake_file"
 +    *-*-darwin2* | *-*-darwin)
-       tmake_file="t-darwin-min-11 $tmake_file"
++      tmake_file="t-darwin-min-11 t-darwin-libgccs1 $tmake_file"
        ;;
      *-*-darwin1[89]*)

--- a/pkgs/development/compilers/gcc/patches/15/libgcc-darwin-fix-reexport.patch
+++ b/pkgs/development/compilers/gcc/patches/15/libgcc-darwin-fix-reexport.patch
@@ -1,0 +1,11 @@
+--- a/libgcc/config/t-slibgcc-darwin
++++ b/libgcc/config/t-slibgcc-darwin
+@@ -139,8 +139,7 @@ libgcc_s.1.dylib: all-multi libgcc_s.$(SHLIB_SOVERSION)$(SHLIB_EXT)
+ 	  $(CC) -arch $${arch} -nodefaultlibs -dynamiclib -nodefaultrpaths \
+ 	    -o libgcc_s.1$(SHLIB_EXT)_T_$${mlib} \
+ 	    -Wl,-reexport_library,libgcc_s.$(SHLIB_SOVERSION)$(SHLIB_EXT)_T_$${mlib} \
+ 	    -lSystem \
+-	    -Wl,-reexported_symbols_list,$(srcdir)/config/darwin-unwind.ver \
+ 	    -install_name $(SHLIB_RPATH)/libgcc_s.1.dylib \
+ 	    -compatibility_version 1 -current_version 1.1 ; \
+ 	done

--- a/pkgs/development/compilers/gcc/patches/c++tools-dont-check-enable-default-pie.patch
+++ b/pkgs/development/compilers/gcc/patches/c++tools-dont-check-enable-default-pie.patch
@@ -1,0 +1,80 @@
+From 3f1f99ef82a65d66e3aaa429bf4fb746b93da0db Mon Sep 17 00:00:00 2001
+From: Kito Cheng <kito.cheng@sifive.com>
+Date: Tue, 27 May 2025 10:10:15 +0800
+Subject: [PATCH] c++tools: Don't check --enable-default-pie.
+
+`--enable-default-pie` is an option to specify whether to enable
+position-independent executables by default for `target`.
+
+However c++tools is build for `host`, so it should just follow
+`--enable-host-pie` option to determine whether to build with
+position-independent executables or not.
+
+NOTE:
+
+I checked PR 98324 and build with same configure option
+(`--enable-default-pie` and lto bootstrap) on x86-64 linux to make sure
+it won't cause same problem.
+
+c++tools/ChangeLog:
+
+	* configure.ac: Don't check `--enable-default-pie`.
+	* configure: Regen.
+---
+ c++tools/configure    | 11 -----------
+ c++tools/configure.ac |  6 ------
+ 2 files changed, 17 deletions(-)
+
+diff --git a/c++tools/configure b/c++tools/configure
+index 1353479becaf4..6df4a2f0dfaed 100755
+--- a/c++tools/configure
++++ b/c++tools/configure
+@@ -700,7 +700,6 @@ enable_option_checking
+ enable_c___tools
+ enable_maintainer_mode
+ enable_checking
+-enable_default_pie
+ enable_host_pie
+ enable_host_bind_now
+ with_gcc_major_version_only
+@@ -1335,7 +1334,6 @@ Optional Features:
+                           enable expensive run-time checks. With LIST, enable
+                           only specific categories of checks. Categories are:
+                           yes,no,all,none,release.
+-  --enable-default-pie    enable Position Independent Executable as default
+   --enable-host-pie       build host code as PIE
+   --enable-host-bind-now  link host code as BIND_NOW
+ 
+@@ -2946,15 +2944,6 @@ $as_echo "#define ENABLE_ASSERT_CHECKING 1" >>confdefs.h
+ 
+ fi
+ 
+-# Check whether --enable-default-pie was given.
+-# Check whether --enable-default-pie was given.
+-if test "${enable_default_pie+set}" = set; then :
+-  enableval=$enable_default_pie; PICFLAG=-fPIE
+-else
+-  PICFLAG=
+-fi
+-
+-
+ # Enable --enable-host-pie
+ # Check whether --enable-host-pie was given.
+ if test "${enable_host_pie+set}" = set; then :
+diff --git a/c++tools/configure.ac b/c++tools/configure.ac
+index db34ee678e033..8c4b72a8023a8 100644
+--- a/c++tools/configure.ac
++++ b/c++tools/configure.ac
+@@ -97,12 +97,6 @@ if test x$ac_assert_checking != x ; then
+ [Define if you want assertions enabled.  This is a cheap check.])
+ fi
+ 
+-# Check whether --enable-default-pie was given.
+-AC_ARG_ENABLE(default-pie,
+-[AS_HELP_STRING([--enable-default-pie],
+-		  [enable Position Independent Executable as default])],
+-[PICFLAG=-fPIE], [PICFLAG=])
+-
+ # Enable --enable-host-pie
+ AC_ARG_ENABLE(host-pie,
+ [AS_HELP_STRING([--enable-host-pie],

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -91,10 +91,12 @@ in
       "14" = [
         ./13/no-sys-dirs-riscv.patch
         ./13/mangle-NIX_STORE-in-__FILE__.patch
+        ./13/libsanitizer-fix-with-glibc-2.42.patch
       ];
       "13" = [
         ./13/no-sys-dirs-riscv.patch
         ./13/mangle-NIX_STORE-in-__FILE__.patch
+        ./13/libsanitizer-fix-with-glibc-2.42.patch
       ];
       "12" = [
         ./no-sys-dirs-riscv.patch

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -125,7 +125,7 @@ in
 ++ optional (atLeast14 && !canApplyIainsDarwinPatches) ./cfi_startproc-reorder-label-14-1.diff
 # c++tools: Don't check --enable-default-pie.
 # --enable-default-pie breaks bootstrap gcc otherwise, because libiberty.a is not found
-++ optional atLeast14 ./c++tools-dont-check-enable-default-pie.patch
+++ optional (is14 || is15) ./c++tools-dont-check-enable-default-pie.patch
 
 ## 2. Patches relevant to gcc>=12 on specific platforms ####################################
 

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -123,6 +123,9 @@ in
 # See https://github.com/NixOS/nixpkgs/pull/354107/commits/2de1b4b14e17f42ba8b4bf43a29347c91511e008
 ++ optional (!atLeast14) ./cfi_startproc-reorder-label-09-1.diff
 ++ optional (atLeast14 && !canApplyIainsDarwinPatches) ./cfi_startproc-reorder-label-14-1.diff
+# c++tools: Don't check --enable-default-pie.
+# --enable-default-pie breaks bootstrap gcc otherwise, because libiberty.a is not found
+++ optional atLeast14 ./c++tools-dont-check-enable-default-pie.patch
 
 ## 2. Patches relevant to gcc>=12 on specific platforms ####################################
 

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -302,6 +302,11 @@ in
     url = "https://inbox.sourceware.org/gcc-patches/20250926170154.2222977-1-corngood@gmail.com/raw";
     hash = "sha256-mgzMRvgPdhj+Q2VRsFhpE2WQzg0CvWsc5/FRAsSU1Es=";
   })
+  (fetchpatch {
+    name = "cygwin-use-builtin_define_std-for-unix.patch";
+    url = "https://inbox.sourceware.org/gcc-patches/20250922182808.2599390-3-corngood@gmail.com/raw";
+    hash = "sha256-8I2G4430gkYoWgUued4unqhk8ZCajHf1dcivAeuLZ0E=";
+  })
 ]
 
 ## Windows

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -186,13 +186,14 @@ in
 
 ## Darwin
 
-# Fixes detection of Darwin on x86_64-darwin. Otherwise, GCC uses a deployment target of 10.5, which crashes ld64.
+# Fixes detection of Darwin on x86_64-darwin and aarch64-darwin. Otherwise, GCC uses a deployment target of 10.5, which crashes ld64.
+++ optional (is14 && stdenv.hostPlatform.isDarwin) ../patches/14/libgcc-darwin-detection.patch
+++ optional (atLeast15 && stdenv.hostPlatform.isDarwin) ../patches/15/libgcc-darwin-detection.patch
+
+# Fix libgcc_s.1.dylib build on Darwin 11+ by not reexporting unwind symbols that don't exist
 ++ optional (
-  is14 && stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
-) ../patches/14/libgcc-darwin-detection.patch
-++ optional (
-  atLeast15 && stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
-) ../patches/15/libgcc-darwin-detection.patch
+  atLeast15 && stdenv.hostPlatform.isDarwin
+) ../patches/15/libgcc-darwin-fix-reexport.patch
 
 # Fix detection of bootstrap compiler Ada support (cctools as) on Nix Darwin
 ++ optional (

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -289,7 +289,7 @@ in
   .${majorVersion} or [ ]
 )
 
-++ optional targetPlatform.isCygwin (fetchpatch {
+++ optional (targetPlatform.isWindows || targetPlatform.isCygwin) (fetchpatch {
   name = "libstdc-fix-compilation-in-freestanding-win32.patch";
   url = "https://inbox.sourceware.org/gcc-patches/20250922182808.2599390-2-corngood@gmail.com/raw";
   hash = "sha256-+EYW9lG8CviVX7RyNHp+iX+8BRHUjt5b07k940khbbY=";

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -192,7 +192,10 @@ in
 ## Darwin
 
 # Fixes detection of Darwin on x86_64-darwin and aarch64-darwin. Otherwise, GCC uses a deployment target of 10.5, which crashes ld64.
-++ optional (is14 && stdenv.hostPlatform.isDarwin) ../patches/14/libgcc-darwin-detection.patch
+++ optional (
+  # this one would conflict with gcc-14-darwin-aarch64-support.patch
+  is14 && stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
+) ../patches/14/libgcc-darwin-detection.patch
 ++ optional (atLeast15 && stdenv.hostPlatform.isDarwin) ../patches/15/libgcc-darwin-detection.patch
 
 # Fix libgcc_s.1.dylib build on Darwin 11+ by not reexporting unwind symbols that don't exist

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -128,6 +128,9 @@ in
 # c++tools: Don't check --enable-default-pie.
 # --enable-default-pie breaks bootstrap gcc otherwise, because libiberty.a is not found
 ++ optional (is14 || is15) ./c++tools-dont-check-enable-default-pie.patch
+# http://gcc.gnu.org/PR120718 backport (will be inclkuded in 15.3.0) to
+# fix `highway-1.3.0` ICE on aarch64-linux.
+++ optional is15 ./15/aarch64-sve-rtx.patch
 
 ## 2. Patches relevant to gcc>=12 on specific platforms ####################################
 

--- a/pkgs/development/cuda-modules/_cuda/manifests/cublasmp/redistrib_0.8.1.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/cublasmp/redistrib_0.8.1.json
@@ -1,0 +1,43 @@
+{
+    "release_date": "2026-03-24",
+    "release_label": "0.8.1",
+    "release_product": "cublasmp",
+    "libcublasmp": {
+        "name": "NVIDIA cuBLASMp library",
+        "license": "cuBLASMp library",
+        "license_path": "libcublasmp/LICENSE.txt",
+        "version": "0.8.1.2360",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "libcublasmp/linux-x86_64/libcublasmp-linux-x86_64-0.8.1.2360_cuda12-archive.tar.xz",
+                "sha256": "25bb1de955d4fb45e25d1adc192c1f872c8a4664e10fa73129d819d0fc310889",
+                "md5": "5e6ef2be18d5b2688e2fcf6341e18450",
+                "size": "12398480"
+            },
+            "cuda13": {
+                "relative_path": "libcublasmp/linux-x86_64/libcublasmp-linux-x86_64-0.8.1.2360_cuda13-archive.tar.xz",
+                "sha256": "e13bca48bca81bd5f6e932d89f1b88e2545beb7d4284814b2b430581183df7ee",
+                "md5": "5b334ad87c5c0ae2a675bf4719a551ce",
+                "size": "6131620"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "libcublasmp/linux-sbsa/libcublasmp-linux-sbsa-0.8.1.2360_cuda12-archive.tar.xz",
+                "sha256": "fe9237eaea88aa45d0eccbe0eead419d71fa6c6206dcbd3fe1e929d571bc7fb9",
+                "md5": "bdc0e29dff8e04c6dae79aac404df0db",
+                "size": "12395780"
+            },
+            "cuda13": {
+                "relative_path": "libcublasmp/linux-sbsa/libcublasmp-linux-sbsa-0.8.1.2360_cuda13-archive.tar.xz",
+                "sha256": "971b4f0e24de7171347b57204c91d204263d2d179d0048a93042aaebcea68f81",
+                "md5": "22a62ca1ca9d86823608f284bc307a1d",
+                "size": "6050756"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/cuquantum/redistrib_25.11.0.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/cuquantum/redistrib_25.11.0.json
@@ -1,0 +1,43 @@
+{
+    "release_date": "2025-11-17",
+    "release_label": "25.11.0",
+    "release_product": "cuquantum",
+    "cuquantum": {
+        "name": "NVIDIA cuQuantum",
+        "license": "cuQuantum",
+        "license_path": "cuquantum/LICENSE.txt",
+        "version": "25.11.0.7",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "cuquantum/linux-x86_64/cuquantum-linux-x86_64-25.11.0.7_cuda12-archive.tar.xz",
+                "sha256": "db0b6b44a5ae92f00e944eeda6a2ff8817531237a104d255fe38eb0d9c3a8fb9",
+                "md5": "c7e8f14db4d6a4dcc69d77a4d85a1986",
+                "size": "193435256"
+            },
+            "cuda13": {
+                "relative_path": "cuquantum/linux-x86_64/cuquantum-linux-x86_64-25.11.0.7_cuda13-archive.tar.xz",
+                "sha256": "644996606142335720eea82cf48bf62cf9f601dde88386bce9bba1dc1d151db5",
+                "md5": "0d5e0f14a1e327e29c495c2c8bbd448a",
+                "size": "212422212"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "cuquantum/linux-sbsa/cuquantum-linux-sbsa-25.11.0.7_cuda12-archive.tar.xz",
+                "sha256": "a1c95f9f52d534e0a18fc2f3a3e8c84722f5a26d6fa888a64527648809242bd6",
+                "md5": "1c443e0822390bbffd87a22977e6c996",
+                "size": "192018404"
+            },
+            "cuda13": {
+                "relative_path": "cuquantum/linux-sbsa/cuquantum-linux-sbsa-25.11.0.7_cuda13-archive.tar.xz",
+                "sha256": "9bb6d88d1b0e51e479b5b05e764c1f8fdb3f8986439c9827f32d98d650e84da1",
+                "md5": "5fe4b66a9e27527e3e81743ddfebfe0f",
+                "size": "211628120"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/cuquantum/redistrib_25.11.1.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/cuquantum/redistrib_25.11.1.json
@@ -1,0 +1,43 @@
+{
+    "release_date": "2025-12-12",
+    "release_label": "25.11.1",
+    "release_product": "cuquantum",
+    "cuquantum": {
+        "name": "NVIDIA cuQuantum",
+        "license": "cuQuantum",
+        "license_path": "cuquantum/LICENSE.txt",
+        "version": "25.11.1.11",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "cuquantum/linux-x86_64/cuquantum-linux-x86_64-25.11.1.11_cuda12-archive.tar.xz",
+                "sha256": "77138174ece7a9a9108e2d44b8ea1e1f2e29874544ea940e13c0d607ad15a358",
+                "md5": "394c8205da24159a6b6280d64e164aff",
+                "size": "192439484"
+            },
+            "cuda13": {
+                "relative_path": "cuquantum/linux-x86_64/cuquantum-linux-x86_64-25.11.1.11_cuda13-archive.tar.xz",
+                "sha256": "dfc063a88547636b316b9682a6834c5fbd2dfd7e823c5fc58857c4251d2ab3c2",
+                "md5": "ee8c8a57c5846f5717601119fc75a3aa",
+                "size": "212506816"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "cuquantum/linux-sbsa/cuquantum-linux-sbsa-25.11.1.11_cuda12-archive.tar.xz",
+                "sha256": "3d3cb33268d97cbe48eea426ea44238ed55c622279fd694f0cf32e47c4564454",
+                "md5": "f40ec796548cc81823aabd441e1ecdbd",
+                "size": "191073088"
+            },
+            "cuda13": {
+                "relative_path": "cuquantum/linux-sbsa/cuquantum-linux-sbsa-25.11.1.11_cuda13-archive.tar.xz",
+                "sha256": "14a44b09d384c27dd36eae9d9858c90140e6422bbd80bda1041ded96ec3c7223",
+                "md5": "ef8ea4357e984d7c828fce6ff2095fec",
+                "size": "211742440"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/cuquantum/redistrib_26.01.0.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/cuquantum/redistrib_26.01.0.json
@@ -1,0 +1,43 @@
+{
+    "release_date": "2026-01-26",
+    "release_label": "26.01.0",
+    "release_product": "cuquantum",
+    "cuquantum": {
+        "name": "NVIDIA cuQuantum",
+        "license": "cuQuantum",
+        "license_path": "cuquantum/LICENSE.txt",
+        "version": "26.01.0.4",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "cuquantum/linux-x86_64/cuquantum-linux-x86_64-26.01.0.4_cuda12-archive.tar.xz",
+                "sha256": "a6120312154f51bddfa50edc9a11d239ed8a2630b893fccf953a73780d656134",
+                "md5": "ea14f9c280d4b83bc457d228b172e5a3",
+                "size": "203960872"
+            },
+            "cuda13": {
+                "relative_path": "cuquantum/linux-x86_64/cuquantum-linux-x86_64-26.01.0.4_cuda13-archive.tar.xz",
+                "sha256": "64781007659513442344f9c9e4e04ead717c991798ccec716808699b99a95d93",
+                "md5": "23fb360480f15ce14c27db30add71c06",
+                "size": "232137156"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "cuquantum/linux-sbsa/cuquantum-linux-sbsa-26.01.0.4_cuda12-archive.tar.xz",
+                "sha256": "1ec3b95b4788a5e7e7d935d25e0cb7f28db8085ecdf851371581bca66be01576",
+                "md5": "23f641d652cb967898fa3205d3c31ec1",
+                "size": "201708072"
+            },
+            "cuda13": {
+                "relative_path": "cuquantum/linux-sbsa/cuquantum-linux-sbsa-26.01.0.4_cuda13-archive.tar.xz",
+                "sha256": "43dc4eee6c7dc2564dc36396bc7cb0775e631c28052c470ebb20fdbf1dd426c1",
+                "md5": "3e2cd172a096561085273036dc1efc0e",
+                "size": "231301012"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/cusolvermp/redistrib_0.7.2.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/cusolvermp/redistrib_0.7.2.json
@@ -1,0 +1,43 @@
+{
+    "release_date": "2025-11-10",
+    "release_label": "0.7.2",
+    "release_product": "cusolvermp",
+    "libcusolvermp": {
+        "name": "NVIDIA libcusolvermp library",
+        "license": "libcusolvermp library",
+        "license_path": "libcusolvermp/LICENSE.txt",
+        "version": "0.7.2.888",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "libcusolvermp/linux-x86_64/libcusolvermp-linux-x86_64-0.7.2.888_cuda12-archive.tar.xz",
+                "sha256": "70243423e07861007ca5a95d35247af4ecdbcd0bf77aa09016a1abf3dcffb6a8",
+                "md5": "5308cd8637fd92486127e8232ffe7586",
+                "size": "11120740"
+            },
+            "cuda13": {
+                "relative_path": "libcusolvermp/linux-x86_64/libcusolvermp-linux-x86_64-0.7.2.888_cuda13-archive.tar.xz",
+                "sha256": "5b7ac5f41e0f2d0ddb226736879c1ad123302d08e4dbccb543dad2c90780888d",
+                "md5": "08f7ded9bfb22d057b59b916cab897d8",
+                "size": "12409996"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "libcusolvermp/linux-sbsa/libcusolvermp-linux-sbsa-0.7.2.888_cuda12-archive.tar.xz",
+                "sha256": "4c1a2688ec0072dec6d9d2303b489a48ad34a419e42ba05f51af68a43221fed6",
+                "md5": "638f149d3415025ecc8735d460a479a5",
+                "size": "10928952"
+            },
+            "cuda13": {
+                "relative_path": "libcusolvermp/linux-sbsa/libcusolvermp-linux-sbsa-0.7.2.888_cuda13-archive.tar.xz",
+                "sha256": "429772ba439da9ac1ea88989a0cc56f2f14b377af349129b1bf913e9357dbbd8",
+                "md5": "e316a14743f1ce0b637bb79a666f95b2",
+                "size": "12084192"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/cusparselt/redistrib_0.9.0.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/cusparselt/redistrib_0.9.0.json
@@ -1,0 +1,38 @@
+{
+    "release_date": "2026-03-23",
+    "release_label": "0.9.0",
+    "release_product": "cusparselt",
+    "libcusparse_lt": {
+        "name": "NVIDIA cuSPARSELt",
+        "license": "cuSPARSELt",
+        "license_path": "libcusparse_lt/LICENSE.txt",
+        "version": "0.9.0.3",
+        "linux-x86_64": {
+            "cuda13": {
+                "relative_path": "libcusparse_lt/linux-x86_64/libcusparse_lt-linux-x86_64-0.9.0.3_cuda13-archive.tar.xz",
+                "sha256": "b3e9f6f366ca7d0701157a0ae7da664ef066b6c3ced92e9f838f387e9bf42b96",
+                "md5": "319d0da2b5b950b4ee1d491ba3082682",
+                "size": "311449432"
+            }
+        },
+        "cuda_variant": [
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda13": {
+                "relative_path": "libcusparse_lt/linux-sbsa/libcusparse_lt-linux-sbsa-0.9.0.3_cuda13-archive.tar.xz",
+                "sha256": "e3a273cbe5ef5293ebe37c5c00446f934ef6af11058498428cbb2de50180bbc9",
+                "md5": "fe1a89f7716e376f9f46ce69eaf06524",
+                "size": "415084400"
+            }
+        },
+        "windows-x86_64": {
+            "cuda13": {
+                "relative_path": "libcusparse_lt/windows-x86_64/libcusparse_lt-windows-x86_64-0.9.0.3_cuda13-archive.zip",
+                "sha256": "3292dc5b2ffeeaf3a9de5eaded690bbcf8115709853b12f88200851ecae8cf1c",
+                "md5": "ec18e887066a32319f5d144424cd0760",
+                "size": "154148270"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/cutensor/redistrib_2.4.0.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/cutensor/redistrib_2.4.0.json
@@ -1,0 +1,57 @@
+{
+    "release_date": "2025-11-17",
+    "release_label": "2.4.0",
+    "release_product": "cutensor",
+    "libcutensor": {
+        "name": "NVIDIA cuTENSOR",
+        "license": "cuTensor",
+        "license_path": "libcutensor/LICENSE.txt",
+        "version": "2.4.0.2",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "libcutensor/linux-x86_64/libcutensor-linux-x86_64-2.4.0.2_cuda12-archive.tar.xz",
+                "sha256": "2703d730343bc5827b2b36698bd2e7d8e348f4459093a8910b47534e65f7b264",
+                "md5": "85cbc0559dea3412b43d6fae98bdaa99",
+                "size": "471791492"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/linux-x86_64/libcutensor-linux-x86_64-2.4.0.2_cuda13-archive.tar.xz",
+                "sha256": "c012b37553bf5c338b7edaeff36a4d2af21d21985af98a5390e4f2c37ad55653",
+                "md5": "453295bc9ddc0d4a477c2b3e6de180c1",
+                "size": "448498120"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.4.0.2_cuda12-archive.tar.xz",
+                "sha256": "0d34fe8655ce183540f15c70b03a4af305141617965ca394058b593372b00ba4",
+                "md5": "053d6d5a61ef1f95d4c56e3bdaff0538",
+                "size": "470123216"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.4.0.2_cuda13-archive.tar.xz",
+                "sha256": "c04c560b87f8b24db7ab32335591a2dacff489f561a56372cb9855ec3da31c19",
+                "md5": "62bc4aceacea2e88ca32596ee9af22c3",
+                "size": "447450280"
+            }
+        },
+        "windows-x86_64": {
+            "cuda12": {
+                "relative_path": "libcutensor/windows-x86_64/libcutensor-windows-x86_64-2.4.0.2_cuda12-archive.zip",
+                "sha256": "2fc6de873c50feb691d701f61220a9ed745a938e56bbd4079ecc56b6a43e746f",
+                "md5": "31ff29e84c4ba88927725c74e3ac88d5",
+                "size": "253915965"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/windows-x86_64/libcutensor-windows-x86_64-2.4.0.2_cuda13-archive.zip",
+                "sha256": "0fe5dd20c7d0a95a145cc96ecf83567f30aff00902843ec87f88c470510b0b82",
+                "md5": "b4f4c87e5c500f6b126e7d7841593326",
+                "size": "183235308"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/cutensor/redistrib_2.4.1.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/cutensor/redistrib_2.4.1.json
@@ -1,0 +1,57 @@
+{
+    "release_date": "2025-12-03",
+    "release_label": "2.4.1",
+    "release_product": "cutensor",
+    "libcutensor": {
+        "name": "NVIDIA cuTENSOR",
+        "license": "cuTensor",
+        "license_path": "libcutensor/LICENSE.txt",
+        "version": "2.4.1.4",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "libcutensor/linux-x86_64/libcutensor-linux-x86_64-2.4.1.4_cuda12-archive.tar.xz",
+                "sha256": "032904fb8bba341e24aa45a8cc7b5afc63e4c28e22474530ccc97cfa546d0442",
+                "md5": "910ffc237ca0827e070d5342d8fb3523",
+                "size": "477937640"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/linux-x86_64/libcutensor-linux-x86_64-2.4.1.4_cuda13-archive.tar.xz",
+                "sha256": "21fb0a9a3b7b6663223667b587f2ab1c54e4a61c975fea0f9d4f56d9c33f31fe",
+                "md5": "4d7885c2ee7a8436015dcc64527385d8",
+                "size": "455163700"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.4.1.4_cuda12-archive.tar.xz",
+                "sha256": "afcf1bd3a50b729bcd5d1ddb0a3e90ca2631d7048d51bdeafe49c650e162ebc1",
+                "md5": "f03dec58e21029a47cb6a199ab194e6a",
+                "size": "476461720"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.4.1.4_cuda13-archive.tar.xz",
+                "sha256": "9baffd3658b7f4da2d2f94d23c3acddb6d12c62997d3da39a774a058fef04aa5",
+                "md5": "ddba7fcb34e5ba66e375b6b24d1e0e5c",
+                "size": "454616920"
+            }
+        },
+        "windows-x86_64": {
+            "cuda12": {
+                "relative_path": "libcutensor/windows-x86_64/libcutensor-windows-x86_64-2.4.1.4_cuda12-archive.zip",
+                "sha256": "39c12490cbe8b30fa5acd200913b66bea960487f3e4d61d5591d448fa5144c95",
+                "md5": "f7e8326d7f095c2f2283d789fce94e6c",
+                "size": "257520274"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/windows-x86_64/libcutensor-windows-x86_64-2.4.1.4_cuda13-archive.zip",
+                "sha256": "cec7dec9670974523cb8ea3a8e893a646b65eca61ad5ca432e89b95542933902",
+                "md5": "38c2aa5fbce57610675d86f37607faee",
+                "size": "186434629"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/cutensor/redistrib_2.5.0.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/cutensor/redistrib_2.5.0.json
@@ -1,0 +1,57 @@
+{
+    "release_date": "2026-01-29",
+    "release_label": "2.5.0",
+    "release_product": "cutensor",
+    "libcutensor": {
+        "name": "NVIDIA cuTENSOR",
+        "license": "cuTensor",
+        "license_path": "libcutensor/LICENSE.txt",
+        "version": "2.5.0.2",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "libcutensor/linux-x86_64/libcutensor-linux-x86_64-2.5.0.2_cuda12-archive.tar.xz",
+                "sha256": "8ebea375994006afa0ebf7b8298e9cce3276f03e661d5ff4401d3232b7e8ca91",
+                "md5": "8900629997917afad439e8b601c8b98e",
+                "size": "486938636"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/linux-x86_64/libcutensor-linux-x86_64-2.5.0.2_cuda13-archive.tar.xz",
+                "sha256": "4bd0e424235e628b8924514706bdac9cf10cf5aa85d9487ce69e58d825f19806",
+                "md5": "7e182ae5aaa8ff60fffd999994aa26d6",
+                "size": "468294076"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.5.0.2_cuda12-archive.tar.xz",
+                "sha256": "08848be5db4760d829c0fa50cc0e56a20555819997160bb619cd8b3086d3bfa8",
+                "md5": "1481147cd7560e7d451173e99b36d03d",
+                "size": "485824568"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.5.0.2_cuda13-archive.tar.xz",
+                "sha256": "82837aa8c18773dce9e034d8f4b230ba3709bc049dd0536db91538b71bd735f4",
+                "md5": "6a90b91423bbb757d850d9016fa291d7",
+                "size": "467116672"
+            }
+        },
+        "windows-x86_64": {
+            "cuda12": {
+                "relative_path": "libcutensor/windows-x86_64/libcutensor-windows-x86_64-2.5.0.2_cuda12-archive.zip",
+                "sha256": "2bf2025c8227f7e5c3b9ec78f191159de0c2f308fb9ba926ca8160e16345e75f",
+                "md5": "9c75574f6d33bcd399b12aa0fc5c5f98",
+                "size": "260707481"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/windows-x86_64/libcutensor-windows-x86_64-2.5.0.2_cuda13-archive.zip",
+                "sha256": "2c615334fc05d7f27bb1528fbd53660edaee31bc503f7af8d2d757e49a1fe090",
+                "md5": "7c98afeb75c51688eb862531bacc2be1",
+                "size": "190620467"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/cutensor/redistrib_2.6.0.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/cutensor/redistrib_2.6.0.json
@@ -1,0 +1,57 @@
+{
+    "release_date": "2026-03-16",
+    "release_label": "2.6.0",
+    "release_product": "cutensor",
+    "libcutensor": {
+        "name": "NVIDIA cuTENSOR",
+        "license": "cuTensor",
+        "license_path": "libcutensor/LICENSE.txt",
+        "version": "2.6.0.4",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "libcutensor/linux-x86_64/libcutensor-linux-x86_64-2.6.0.4_cuda12-archive.tar.xz",
+                "sha256": "28dbda315a95b3edc58af986ff1b886dcf2bd1c9651094539011bbce234cb9ae",
+                "md5": "0b99e3061c4d20886de4c5644fc02bed",
+                "size": "478036324"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/linux-x86_64/libcutensor-linux-x86_64-2.6.0.4_cuda13-archive.tar.xz",
+                "sha256": "f70003a4817da3db2f1f7726328c31332ada89a496446fe30b90f414eccda487",
+                "md5": "0951f42d187a1592a73774255f7bfe8e",
+                "size": "461942624"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.6.0.4_cuda12-archive.tar.xz",
+                "sha256": "f057367cabfc459b5e66e295b724b00ed780defda3ccfb62a98c8817df46b8b5",
+                "md5": "9f95dfafd90e7b56e5f45048c123998b",
+                "size": "479924536"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/linux-sbsa/libcutensor-linux-sbsa-2.6.0.4_cuda13-archive.tar.xz",
+                "sha256": "f9e85439174f64d6e84db9ea54b101a24ca751b7e94ceccbfd5181be22980310",
+                "md5": "78261c4b5a698a2f7154aa0e6b9a8398",
+                "size": "460451040"
+            }
+        },
+        "windows-x86_64": {
+            "cuda12": {
+                "relative_path": "libcutensor/windows-x86_64/libcutensor-windows-x86_64-2.6.0.4_cuda12-archive.zip",
+                "sha256": "05e29d4dd2472b2261893979f2e35b7ef27563ba47976ecdc121d88660d86186",
+                "md5": "d428eb70c02b2f8709787aeff2f45c5a",
+                "size": "256996457"
+            },
+            "cuda13": {
+                "relative_path": "libcutensor/windows-x86_64/libcutensor-windows-x86_64-2.6.0.4_cuda13-archive.zip",
+                "sha256": "005257fb07789669605eaa4e6e5cf46a55dbade3194db03931cdbb900711e626",
+                "md5": "5433ea4665d41171fa4b86f85a16aa25",
+                "size": "187226952"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/nvcomp/redistrib_5.1.0.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/nvcomp/redistrib_5.1.0.json
@@ -1,0 +1,57 @@
+{
+    "release_date": "2025-12-01",
+    "release_label": "5.1.0",
+    "release_product": "nvcomp",
+    "nvcomp": {
+        "name": "NVIDIA nvCOMP library",
+        "license": "nvCOMP library",
+        "license_path": "nvcomp/LICENSE.txt",
+        "version": "5.1.0.21",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "nvcomp/linux-x86_64/nvcomp-linux-x86_64-5.1.0.21_cuda12-archive.tar.xz",
+                "sha256": "bea7ea6c7f006b817dcb33a60d89c03f45684489ddc20295dc464af0505afd7c",
+                "md5": "148ff6bd87122482359cc46ca1aefe2a",
+                "size": "39776712"
+            },
+            "cuda13": {
+                "relative_path": "nvcomp/linux-x86_64/nvcomp-linux-x86_64-5.1.0.21_cuda13-archive.tar.xz",
+                "sha256": "2b3e2d0cd62e9185868359802550612deecf3cb9efe5f3e190ef2b64d4cb1957",
+                "md5": "26973bddbcbc9a85c7451daf969440c4",
+                "size": "37332472"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "nvcomp/linux-sbsa/nvcomp-linux-sbsa-5.1.0.21_cuda12-archive.tar.xz",
+                "sha256": "023b2b63ec20e29cd4dcf4dd2a6690a21cd325fa08b3e09a47c74d28e4d2bb82",
+                "md5": "08b4f0ef043ad1cecbe9062a7e151496",
+                "size": "39684168"
+            },
+            "cuda13": {
+                "relative_path": "nvcomp/linux-sbsa/nvcomp-linux-sbsa-5.1.0.21_cuda13-archive.tar.xz",
+                "sha256": "38968cccf31c51430db36580152af64b45a93f08ffedf7bbae12321fea62eaba",
+                "md5": "13950269f3eb3670c24276bae89ba206",
+                "size": "37167052"
+            }
+        },
+        "windows-x86_64": {
+            "cuda12": {
+                "relative_path": "nvcomp/windows-x86_64/nvcomp-windows-x86_64-5.1.0.21_cuda12-archive.zip",
+                "sha256": "1225006a689416f1599fabbe20c81f048932c959bf7a099e39f47b41bea3e7fa",
+                "md5": "12fa2f886b39ba88603d3e7be06077e0",
+                "size": "62105334"
+            },
+            "cuda13": {
+                "relative_path": "nvcomp/windows-x86_64/nvcomp-windows-x86_64-5.1.0.21_cuda13-archive.zip",
+                "sha256": "01b7bb6354f10226b581356df81f05cfd504479f99dbb38df0a4b83393428977",
+                "md5": "b8c76a9a6042feabd3d15d90d1e92f4a",
+                "size": "43985399"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/nvjpeg2000/redistrib_0.9.1.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/nvjpeg2000/redistrib_0.9.1.json
@@ -1,0 +1,65 @@
+{
+    "release_date": "2025-11-13",
+    "release_label": "0.9.1",
+    "release_product": "nvjpeg2000",
+    "libnvjpeg_2k": {
+        "name": "NVIDIA nvJPEG 2000",
+        "license": "nvJPEG 2K",
+        "license_path": "libnvjpeg_2k/LICENSE.txt",
+        "version": "0.9.1.47",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "libnvjpeg_2k/linux-x86_64/libnvjpeg_2k-linux-x86_64-0.9.1.47_cuda12-archive.tar.xz",
+                "sha256": "5803ed38253923578a2ae3b21dabdc963c4effccfed07ca5e1e3acb84ecd1535",
+                "md5": "5204101e482cd0d5d6087bf3829cb63d",
+                "size": "7902528"
+            },
+            "cuda13": {
+                "relative_path": "libnvjpeg_2k/linux-x86_64/libnvjpeg_2k-linux-x86_64-0.9.1.47_cuda13-archive.tar.xz",
+                "sha256": "34d482f4145cbdda731e66f8c31e2019385e24274f00892bb112a6523758d11f",
+                "md5": "84942233a9bc3a5c34b915525cfe5aa6",
+                "size": "2465668"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "libnvjpeg_2k/linux-sbsa/libnvjpeg_2k-linux-sbsa-0.9.1.47_cuda12-archive.tar.xz",
+                "sha256": "25878f583c9797146aa7b396f8219da23f388780c4fc4f72121300aace9ba1b3",
+                "md5": "48d958f04b5024aa3028366e36457a13",
+                "size": "7798632"
+            },
+            "cuda13": {
+                "relative_path": "libnvjpeg_2k/linux-sbsa/libnvjpeg_2k-linux-sbsa-0.9.1.47_cuda13-archive.tar.xz",
+                "sha256": "4e85e0eec6f08b4300a827e028f4f28c20b641adf361c795569c25947cb19852",
+                "md5": "2545f5f47a14e8f57a38fb60c33e280d",
+                "size": "2675048"
+            }
+        },
+        "windows-x86_64": {
+            "cuda12": {
+                "relative_path": "libnvjpeg_2k/windows-x86_64/libnvjpeg_2k-windows-x86_64-0.9.1.47_cuda12-archive.zip",
+                "sha256": "f732791bae840f84a905544a398856adad2701ea3cb510ee72582c555c700fd4",
+                "md5": "eec6403d07b07346e36973ccf0a0202e",
+                "size": "6884082"
+            },
+            "cuda13": {
+                "relative_path": "libnvjpeg_2k/windows-x86_64/libnvjpeg_2k-windows-x86_64-0.9.1.47_cuda13-archive.zip",
+                "sha256": "82f32f3fc416769b64dcce2d605b1bfc0cbc1e3149c19b03f6042f2c99ebd2d1",
+                "md5": "bde3547312db30969f581c6ab4011db3",
+                "size": "2206826"
+            }
+        },
+        "linux-aarch64": {
+            "cuda12": {
+                "relative_path": "libnvjpeg_2k/linux-aarch64/libnvjpeg_2k-linux-aarch64-0.9.1.47_cuda12-archive.tar.xz",
+                "sha256": "7c0585d538b97aef4c41b126a90c387c0e9d4f18be6166a76c2a264ffc8c1217",
+                "md5": "efbbcb15ccf9537ec11da6848fb814da",
+                "size": "2451500"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/nvpl/redistrib_25.11.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/nvpl/redistrib_25.11.json
@@ -1,0 +1,101 @@
+{
+    "release_date": "2025-11-20",
+    "release_label": "25.11",
+    "release_product": "nvpl",
+    "nvpl_blas": {
+        "name": "NVPL BLAS",
+        "license": "NVPL",
+        "license_path": "nvpl_blas/LICENSE.txt",
+        "version": "0.5.0.1",
+        "linux-sbsa": {
+            "relative_path": "nvpl_blas/linux-sbsa/nvpl_blas-linux-sbsa-0.5.0.1-archive.tar.xz",
+            "sha256": "c51fc9cc908cca7c6aa39e72c492c2bfcc9472b542b109b6bcfa5d143f9d780e",
+            "md5": "13bfb0bd82d7f009cb4e0bbde3da852a",
+            "size": "778720"
+        }
+    },
+    "nvpl_common": {
+        "name": "NVPL Common",
+        "license": "NVPL",
+        "license_path": "nvpl_common/LICENSE.txt",
+        "version": "0.3.4",
+        "linux-sbsa": {
+            "relative_path": "nvpl_common/linux-sbsa/nvpl_common-linux-sbsa-0.3.4-archive.tar.xz",
+            "sha256": "c68891dd293df0faf2ae3cebfeae69c567cf784c98006351abcde2a34fc387df",
+            "md5": "cdf0255f2b9088c66ffe35b7e4225389",
+            "size": "9448"
+        }
+    },
+    "nvpl_fft": {
+        "name": "NVPL FFT",
+        "license": "NVPL",
+        "license_path": "nvpl_fft/LICENSE.txt",
+        "version": "0.5.0",
+        "linux-sbsa": {
+            "relative_path": "nvpl_fft/linux-sbsa/nvpl_fft-linux-sbsa-0.5.0-archive.tar.xz",
+            "sha256": "fc53bf42124b0e395230109cea5c325fd6963b8797bdd98aa127cb402e92e813",
+            "md5": "c067a1c47828b4a01adb77562947fbf2",
+            "size": "26393704"
+        }
+    },
+    "nvpl_lapack": {
+        "name": "NVPL LAPACK",
+        "license": "NVPL",
+        "license_path": "nvpl_lapack/LICENSE.txt",
+        "version": "0.3.2",
+        "linux-sbsa": {
+            "relative_path": "nvpl_lapack/linux-sbsa/nvpl_lapack-linux-sbsa-0.3.2-archive.tar.xz",
+            "sha256": "3e4d9969223a52ab011d1bf38156cbe31fba0e4f12c3b87729393972a16daecf",
+            "md5": "fdff7194b1f8e58cbe29761a15887b46",
+            "size": "5747200"
+        }
+    },
+    "nvpl_rand": {
+        "name": "NVPL RAND",
+        "license": "NVPL",
+        "license_path": "nvpl_rand/LICENSE.txt",
+        "version": "0.5.3",
+        "linux-sbsa": {
+            "relative_path": "nvpl_rand/linux-sbsa/nvpl_rand-linux-sbsa-0.5.3-archive.tar.xz",
+            "sha256": "fe23e00cbd5c15f33242ba44049cca5bf2ff93f52196380ccbcf9a250e9d22a2",
+            "md5": "f8e825d359d1abb376fe20cd94b001a8",
+            "size": "34012984"
+        }
+    },
+    "nvpl_scalapack": {
+        "name": "NVPL SCALAPACK",
+        "license": "NVPL",
+        "license_path": "nvpl_scalapack/LICENSE.txt",
+        "version": "0.2.3",
+        "linux-sbsa": {
+            "relative_path": "nvpl_scalapack/linux-sbsa/nvpl_scalapack-linux-sbsa-0.2.3-archive.tar.xz",
+            "sha256": "1afa2a6f2ab0580bff2148cc769e4c03f79a5de622c89699564287dd1a1112cf",
+            "md5": "02baaa1ce9db99d8945a573c8dbe71ce",
+            "size": "4723472"
+        }
+    },
+    "nvpl_sparse": {
+        "name": "NVPL SPARSE",
+        "license": "NVPL",
+        "license_path": "nvpl_sparse/LICENSE.txt",
+        "version": "0.5.0",
+        "linux-sbsa": {
+            "relative_path": "nvpl_sparse/linux-sbsa/nvpl_sparse-linux-sbsa-0.5.0-archive.tar.xz",
+            "sha256": "bfc11bb0cd004e6415f6857807eb99b09a68e6ea84c2f7b466b462e879880e1f",
+            "md5": "2d9ec05bf4f02d97043f2179c1acf26b",
+            "size": "847304"
+        }
+    },
+    "nvpl_tensor": {
+        "name": "NVPL TENSOR",
+        "license": "NVPL",
+        "license_path": "nvpl_tensor/LICENSE.txt",
+        "version": "0.3.2.1",
+        "linux-sbsa": {
+            "relative_path": "nvpl_tensor/linux-sbsa/nvpl_tensor-linux-sbsa-0.3.2.1-archive.tar.xz",
+            "sha256": "e491ccb5fb4fb7df26665b204c337e0511a60b97edf354bd44e778942e4bd5c6",
+            "md5": "c0cc5193fc8670d11d79637bb168aae6",
+            "size": "2784084"
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/nvtiff/redistrib_0.6.0.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/nvtiff/redistrib_0.6.0.json
@@ -1,0 +1,65 @@
+{
+    "release_date": "2025-11-13",
+    "release_label": "0.6.0",
+    "release_product": "nvtiff",
+    "libnvtiff": {
+        "version": "0.6.0.78",
+        "linux-x86_64": {
+            "cuda12": {
+                "relative_path": "libnvtiff/linux-x86_64/libnvtiff-linux-x86_64-0.6.0.78_cuda12-archive.tar.xz",
+                "sha256": "2c889bf4767e4ab8e81f46e9f2b675e1d424c46e4a54bb97049bbb3b87ff4aed",
+                "md5": "f65b6a531051fe1b10ba93e0de881184",
+                "size": "2104500"
+            },
+            "cuda13": {
+                "relative_path": "libnvtiff/linux-x86_64/libnvtiff-linux-x86_64-0.6.0.78_cuda13-archive.tar.xz",
+                "sha256": "8018c8dcff3bcac9f0e74827d312f67169b9fd01b40b2bbb431dd9bf8a5c38aa",
+                "md5": "a26e4c47464314c2b6d95b8422eb968c",
+                "size": "1597244"
+            }
+        },
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda12": {
+                "relative_path": "libnvtiff/linux-sbsa/libnvtiff-linux-sbsa-0.6.0.78_cuda12-archive.tar.xz",
+                "sha256": "3694b154003a3741b68fc9ff70ad9195a756be1feb2404be6f2482bb97574c00",
+                "md5": "c5c40f16eccbd47607f8d71e58eee13b",
+                "size": "2015332"
+            },
+            "cuda13": {
+                "relative_path": "libnvtiff/linux-sbsa/libnvtiff-linux-sbsa-0.6.0.78_cuda13-archive.tar.xz",
+                "sha256": "a0667c222c41186b9bf4fbc447281375bd83ec4b4c6658c37440149b78df4f41",
+                "md5": "958baa5b74f453e4bc911f64860528a3",
+                "size": "1687736"
+            }
+        },
+        "name": "NVIDIA nvTIFF",
+        "license": "nvTIFF",
+        "license_path": "libnvtiff/LICENSE.txt",
+        "windows-x86_64": {
+            "cuda12": {
+                "relative_path": "libnvtiff/windows-x86_64/libnvtiff-windows-x86_64-0.6.0.78_cuda12-archive.zip",
+                "sha256": "1eb6848921808f28d703320f52ac584743a365d9bef4b105482db2d63e01f039",
+                "md5": "998c58e5a0f1795fc9ef75128c50cfbb",
+                "size": "2027376"
+            },
+            "cuda13": {
+                "relative_path": "libnvtiff/windows-x86_64/libnvtiff-windows-x86_64-0.6.0.78_cuda13-archive.zip",
+                "sha256": "8a99af1fd4919fe21829bf05e3e4b87aa2adb563e409a86ee54d2746f01f0045",
+                "md5": "7d75da9ffa918f9a95b62d6d203873ac",
+                "size": "1300531"
+            }
+        },
+        "linux-aarch64": {
+            "cuda12": {
+                "relative_path": "libnvtiff/linux-aarch64/libnvtiff-linux-aarch64-0.6.0.78_cuda12-archive.tar.xz",
+                "sha256": "1c1707880f6438dee0fcf58ab2cc62125e8140c90a983029ef6186aa7a8dc798",
+                "md5": "46cf31ec42e69e31bb6a129088621929",
+                "size": "1346184"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/redistrib_10.15.1.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/redistrib_10.15.1.json
@@ -1,0 +1,36 @@
+{
+    "release_date": "2026-01-29",
+    "release_label": "10.15.1",
+    "release_product": "tensorrt",
+    "tensorrt": {
+        "name": "NVIDIA TensorRT",
+        "license": "TensorRT",
+        "version": "10.15.1.29",
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda13": {
+                "md5": "78997d48b4b90d8ed51f302fd66de436",
+                "relative_path": "tensorrt/10.15.1/tars/TensorRT-10.15.1.29.Linux.aarch64-gnu.cuda-13.1.tar.gz",
+                "sha256": "df0c112a4d66bd8ef890697297e01558d7338d5c4ac85d4078e814e506bd6da2",
+                "size": "5537818569"
+            }
+        },
+        "linux-x86_64": {
+            "cuda12": {
+                "md5": "a90343e21d96c0dce04043b8a1fa895c",
+                "relative_path": "tensorrt/10.15.1/tars/TensorRT-10.15.1.29.Linux.x86_64-gnu.cuda-12.9.tar.gz",
+                "sha256": "e0a3f323e0220c1aed3d10aafc12e452a3301688875fe8a6b36f6f6052d446ef",
+                "size": "8468717726"
+            },
+            "cuda13": {
+                "md5": "db7010d2bee07523c66c29172dd29a8c",
+                "relative_path": "tensorrt/10.15.1/tars/TensorRT-10.15.1.29.Linux.x86_64-gnu.cuda-13.1.tar.gz",
+                "sha256": "2e2d6e800221e840e1fc7eba7a5e4b13390cf14856b4b21af429694e21602222",
+                "size": "7490473889"
+            }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/redistrib_10.16.0.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/redistrib_10.16.0.json
@@ -1,0 +1,36 @@
+{
+    "release_date": "2026-03-17",
+    "release_label": "10.16.0",
+    "release_product": "tensorrt",
+    "tensorrt": {
+        "name": "NVIDIA TensorRT",
+        "license": "TensorRT",
+        "version": "10.16.0.72",
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+            "cuda13": {
+                "md5": "7543333e675f904ccd1ba9bae741fe5d",
+                "relative_path": "tensorrt/10.16.0/tars/TensorRT-10.16.0.72.Linux.aarch64-gnu.cuda-13.2.tar.gz",
+                "sha256": "3c6d8fa73a35bc0affe0bba22956f162796df27ea410f38cced721bb8572c1dc",
+                "size": "5617840535"
+            }
+        },
+        "linux-x86_64": {
+            "cuda12": {
+                "md5": "8bb58ff70b4be0860c1606e412f30a9e",
+                "relative_path": "tensorrt/10.16.0/tars/TensorRT-10.16.0.72.Linux.x86_64-gnu.cuda-12.9.tar.gz",
+                "sha256": "1482e22b572b5a3e9d8ae30093ea06436f502205e14cd382b6ff2fbc3c957bf0",
+                "size": "8546977920"
+            },
+            "cuda13": {
+                "md5": "3176d65a444d51eb9a61736fa329d1e9",
+                "relative_path": "tensorrt/10.16.0/tars/TensorRT-10.16.0.72.Linux.x86_64-gnu.cuda-13.2.tar.gz",
+                "sha256": "956a28dcee7b408b1897108288e010c61c0b2d9bedb6cf00e3fbc8f9c6b07042",
+                "size": "7568039306"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Manifest bumps and backports of upstream changes to compilers.

NOTE: Version updates which invalidate certain configurations (e.g., if a package version bump also removes support for some GPU) don't have those configurations caught as a runtime error. Most package expressions live in Nixpkgs and contain that information, so they will be updated (best-effort) with those checks in time.

Added some lines to the README to communicate the pin for NixOS 25.11 (since we pin to a stable branch) is a strict lower bound, since we depend on fixes and changes that have made it into that branch around that time. Use with arbitrary versions of Nixpkgs is not supported since that would require essentially venturing new copies of every expression any time there's a change upstream which leverages new in-tree functionality (for example, the implementation of the problems RFC allowing us to stop using our own version: https://github.com/NixOS/nixpkgs/pull/494416).