### PR TITLE
fixup: gcc13,gcc14: fix build w/ glibc-2.42

### DIFF
--- a/pkgs/development/compilers/gcc/patches/11/libsanitizer-fix-with-glibc-2.42.patch
+++ b/pkgs/development/compilers/gcc/patches/11/libsanitizer-fix-with-glibc-2.42.patch
@@ -1,0 +1,70 @@
+diff --git a/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc b/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+index 42e43a04441..fcaa45d5224 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
++++ b/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+@@ -330,13 +330,9 @@ static void ioctl_table_fill() {
+   _(SOUND_PCM_WRITE_CHANNELS, WRITE, sizeof(int));
+   _(SOUND_PCM_WRITE_FILTER, WRITE, sizeof(int));
+   _(TCFLSH, NONE, 0);
+-  _(TCGETA, WRITE, struct_termio_sz);
+   _(TCGETS, WRITE, struct_termios_sz);
+   _(TCSBRK, NONE, 0);
+   _(TCSBRKP, NONE, 0);
+-  _(TCSETA, READ, struct_termio_sz);
+-  _(TCSETAF, READ, struct_termio_sz);
+-  _(TCSETAW, READ, struct_termio_sz);
+   _(TCSETS, READ, struct_termios_sz);
+   _(TCSETSF, READ, struct_termios_sz);
+   _(TCSETSW, READ, struct_termios_sz);
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+index 5743516c046..484cdc5b045 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp
+@@ -423,7 +423,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned struct_input_id_sz = sizeof(struct input_id);
+   unsigned struct_mtpos_sz = sizeof(struct mtpos);
+   unsigned struct_rtentry_sz = sizeof(struct rtentry);
+-  unsigned struct_termio_sz = sizeof(struct termio);
+   unsigned struct_vt_consize_sz = sizeof(struct vt_consize);
+   unsigned struct_vt_sizes_sz = sizeof(struct vt_sizes);
+   unsigned struct_vt_stat_sz = sizeof(struct vt_stat);
+@@ -694,13 +693,9 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned IOCTL_SOUND_PCM_WRITE_FILTER = SOUND_PCM_WRITE_FILTER;
+ #endif // SOUND_VERSION
+   unsigned IOCTL_TCFLSH = TCFLSH;
+-  unsigned IOCTL_TCGETA = TCGETA;
+   unsigned IOCTL_TCGETS = TCGETS;
+   unsigned IOCTL_TCSBRK = TCSBRK;
+   unsigned IOCTL_TCSBRKP = TCSBRKP;
+-  unsigned IOCTL_TCSETA = TCSETA;
+-  unsigned IOCTL_TCSETAF = TCSETAF;
+-  unsigned IOCTL_TCSETAW = TCSETAW;
+   unsigned IOCTL_TCSETS = TCSETS;
+   unsigned IOCTL_TCSETSF = TCSETSF;
+   unsigned IOCTL_TCSETSW = TCSETSW;
+diff --git a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+index 83861105a50..1f27f89afce 100644
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -959,7 +959,6 @@ extern unsigned struct_hd_geometry_sz;
+ extern unsigned struct_input_absinfo_sz;
+ extern unsigned struct_input_id_sz;
+ extern unsigned struct_mtpos_sz;
+-extern unsigned struct_termio_sz;
+ extern unsigned struct_vt_consize_sz;
+ extern unsigned struct_vt_sizes_sz;
+ extern unsigned struct_vt_stat_sz;
+@@ -1196,13 +1195,9 @@ extern unsigned IOCTL_SNDCTL_COPR_SENDMSG;
+ extern unsigned IOCTL_SNDCTL_COPR_WCODE;
+ extern unsigned IOCTL_SNDCTL_COPR_WDATA;
+ extern unsigned IOCTL_TCFLSH;
+-extern unsigned IOCTL_TCGETA;
+ extern unsigned IOCTL_TCGETS;
+ extern unsigned IOCTL_TCSBRK;
+ extern unsigned IOCTL_TCSBRKP;
+-extern unsigned IOCTL_TCSETA;
+-extern unsigned IOCTL_TCSETAF;
+-extern unsigned IOCTL_TCSETAW;
+ extern unsigned IOCTL_TCSETS;
+ extern unsigned IOCTL_TCSETSF;
+ extern unsigned IOCTL_TCSETSW;

--- a/pkgs/development/compilers/gcc/patches/9/libsanitizer-fix-with-glibc-2.42.patch
+++ b/pkgs/development/compilers/gcc/patches/9/libsanitizer-fix-with-glibc-2.42.patch
@@ -1,0 +1,64 @@
+--- a/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
++++ b/libsanitizer/sanitizer_common/sanitizer_common_interceptors_ioctl.inc
+@@ -329,13 +329,9 @@ static void ioctl_table_fill() {
+   _(SOUND_PCM_WRITE_CHANNELS, WRITE, sizeof(int));
+   _(SOUND_PCM_WRITE_FILTER, WRITE, sizeof(int));
+   _(TCFLSH, NONE, 0);
+-  _(TCGETA, WRITE, struct_termio_sz);
+   _(TCGETS, WRITE, struct_termios_sz);
+   _(TCSBRK, NONE, 0);
+   _(TCSBRKP, NONE, 0);
+-  _(TCSETA, READ, struct_termio_sz);
+-  _(TCSETAF, READ, struct_termio_sz);
+-  _(TCSETAW, READ, struct_termio_sz);
+   _(TCSETS, READ, struct_termios_sz);
+   _(TCSETSF, READ, struct_termios_sz);
+   _(TCSETSW, READ, struct_termios_sz);
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -438,7 +438,6 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned struct_input_id_sz = sizeof(struct input_id);
+   unsigned struct_mtpos_sz = sizeof(struct mtpos);
+   unsigned struct_rtentry_sz = sizeof(struct rtentry);
+-  unsigned struct_termio_sz = sizeof(struct termio);
+   unsigned struct_vt_consize_sz = sizeof(struct vt_consize);
+   unsigned struct_vt_sizes_sz = sizeof(struct vt_sizes);
+   unsigned struct_vt_stat_sz = sizeof(struct vt_stat);
+@@ -707,13 +706,9 @@ unsigned struct_ElfW_Phdr_sz = sizeof(Elf_Phdr);
+   unsigned IOCTL_SOUND_PCM_WRITE_FILTER = SOUND_PCM_WRITE_FILTER;
+ #endif // SOUND_VERSION
+   unsigned IOCTL_TCFLSH = TCFLSH;
+-  unsigned IOCTL_TCGETA = TCGETA;
+   unsigned IOCTL_TCGETS = TCGETS;
+   unsigned IOCTL_TCSBRK = TCSBRK;
+   unsigned IOCTL_TCSBRKP = TCSBRKP;
+-  unsigned IOCTL_TCSETA = TCSETA;
+-  unsigned IOCTL_TCSETAF = TCSETAF;
+-  unsigned IOCTL_TCSETAW = TCSETAW;
+   unsigned IOCTL_TCSETS = TCSETS;
+   unsigned IOCTL_TCSETSF = TCSETSF;
+   unsigned IOCTL_TCSETSW = TCSETSW;
+--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -1018,7 +1018,6 @@ struct __sanitizer_cookie_io_functions_t {
+   extern unsigned struct_input_absinfo_sz;
+   extern unsigned struct_input_id_sz;
+   extern unsigned struct_mtpos_sz;
+-  extern unsigned struct_termio_sz;
+   extern unsigned struct_vt_consize_sz;
+   extern unsigned struct_vt_sizes_sz;
+   extern unsigned struct_vt_stat_sz;
+@@ -1253,13 +1252,9 @@ struct __sanitizer_cookie_io_functions_t {
+   extern unsigned IOCTL_SNDCTL_COPR_WCODE;
+   extern unsigned IOCTL_SNDCTL_COPR_WDATA;
+   extern unsigned IOCTL_TCFLSH;
+-  extern unsigned IOCTL_TCGETA;
+   extern unsigned IOCTL_TCGETS;
+   extern unsigned IOCTL_TCSBRK;
+   extern unsigned IOCTL_TCSBRKP;
+-  extern unsigned IOCTL_TCSETA;
+-  extern unsigned IOCTL_TCSETAF;
+-  extern unsigned IOCTL_TCSETAW;
+   extern unsigned IOCTL_TCSETS;
+   extern unsigned IOCTL_TCSETSF;
+   extern unsigned IOCTL_TCSETSW;

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -101,10 +101,20 @@ in
       "12" = [
         ./no-sys-dirs-riscv.patch
         ./12/mangle-NIX_STORE-in-__FILE__.patch
+        ./13/libsanitizer-fix-with-glibc-2.42.patch
       ];
-      "11" = [ ./no-sys-dirs-riscv.patch ];
-      "10" = [ ./no-sys-dirs-riscv.patch ];
-      "9" = [ ./no-sys-dirs-riscv-gcc9.patch ];
+      "11" = [
+        ./no-sys-dirs-riscv.patch
+        ./11/libsanitizer-fix-with-glibc-2.42.patch
+      ];
+      "10" = [
+        ./no-sys-dirs-riscv.patch
+        ./11/libsanitizer-fix-with-glibc-2.42.patch
+      ];
+      "9" = [
+        ./no-sys-dirs-riscv-gcc9.patch
+        ./9/libsanitizer-fix-with-glibc-2.42.patch
+      ];
     }
     ."${majorVersion}" or [ ]
   )


### PR DESCRIPTION
This is a fixup for this commit's parent, which applies patches to GCC 13/14 to fix their build with glibc 2.42. Similar patches need to be applied to all pre-13 GCC versions within cuda-legacy.

That commit as applied previously added the needed patch for gcc 9, but didn't apply it. Additionally, we need to create a version of this patch which applies to gcc 10 and 11, as neither the gcc 13 nor gcc 9 versions of this patch apply cleanly. For gcc 12, the gcc 13 patch applies cleanly.