### PR TITLE
26.05 git am patch series

### DIFF
--- a/pkgs/development/compilers/gcc/all.nix
+++ b/pkgs/development/compilers/gcc/all.nix
@@ -13,6 +13,9 @@
 
 let
   versions = import ./versions.nix;
+  buildIsHost = lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform;
+  buildIsTarget = lib.systems.equals stdenv.buildPlatform stdenv.targetPlatform;
+  hostIsTarget = lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform;
   gccForMajorVersion =
     majorVersion:
     let
@@ -23,18 +26,13 @@ let
             inherit noSysDirs;
             # TODO(@connorbaker): Why are they assuming two-component versions and not failing when they get one?
             majorMinorVersion = majorVersion;
+            _systemInfo = {
+              inherit buildIsHost hostIsTarget;
+            };
             reproducibleBuild = true;
             profiledCompiler = false;
-            libcCross =
-              if !lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform then
-                targetPackages.libc or pkgs.libc
-              else
-                null;
-            threadsCross =
-              if !lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform then
-                targetPackages.threads or pkgs.threads
-              else
-                { };
+            libcCross = if !buildIsTarget then targetPackages.libc or pkgs.libc else null;
+            threadsCross = if !buildIsTarget then targetPackages.threads or pkgs.threads else { };
             isl = if stdenv.hostPlatform.isDarwin then null else isl_0_20;
             # do not allow version skew when cross-building gcc
             #
@@ -55,13 +53,7 @@ let
             # Let's fix both problems by requiring the same compiler version for
             # cross-case.
             stdenv =
-              if
-                (
-                  (!lib.systems.equals stdenv.targetPlatform stdenv.buildPlatform)
-                  || (!lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform)
-                )
-                && stdenv.cc.isGNU
-              then
+              if (!buildIsTarget || !hostIsTarget) && stdenv.cc.isGNU then
                 overrideCC stdenv buildPackages."gcc${majorVersion}"
               else
                 stdenv;

--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -3,11 +3,12 @@
   stdenv,
   enableMultilib,
   targetConfig,
+  hostIsTarget,
 }:
 
 let
   forceLibgccToBuildCrtStuff = import ./libgcc-buildstuff.nix { inherit lib stdenv; };
-  isCross = !lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform;
+  isCross = !hostIsTarget;
 in
 
 # We don't support multilib and cross at the same time

--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -278,106 +278,117 @@ originalAttrs:
           makeCompatibilitySymlink lib $targetConfig/lib64
         '';
 
-    postInstall = ''
-      # Clean up our compatibility symlinks (see above)
-      for link in "''${compatibilitySymlinks[@]}"; do
-        echo "Removing compatibility symlink: $link"
-        rm -f "$link"
-      done
-
-      # Move target runtime libraries to lib output.
-      # For non-cross, they're in $out/lib; for cross, they're in $out/$targetConfig/lib.
-      targetLibDir="''${targetConfig+$targetConfig/}lib"
-
-      moveToOutput "$targetLibDir/lib*.so*" "''${!outputLib}"
-      moveToOutput "$targetLibDir/lib*.dylib" "''${!outputLib}"
-      moveToOutput "$targetLibDir/lib*.dll.a" "''${!outputLib}"
-      moveToOutput "$targetLibDir/lib*.dll" "''${!outputLib}"
-      moveToOutput "share/gcc-*/python" "''${!outputLib}"
-
-      if [ -z "$enableShared" ]; then
-          moveToOutput "$targetLibDir/lib*.a" "''${!outputLib}"
-      fi
-
-      for i in "''${!outputLib}"/$targetLibDir/*.py; do
-          substituteInPlace "$i" --replace "$out" "''${!outputLib}"
-      done
-
-      # Multilib and cross can't exist at the same time, so just use lib64 here
-      if [ -n "$enableMultilib" ]; then
-          moveToOutput "lib64/lib*.so*" "''${!outputLib}"
-          moveToOutput "lib64/lib*.dylib" "''${!outputLib}"
-          moveToOutput "lib64/lib*.dll.a" "''${!outputLib}"
-          moveToOutput "lib64/lib*.dll" "''${!outputLib}"
-
-          for i in "''${!outputLib}"/lib64/*.py; do
-              substituteInPlace "$i" --replace "$out" "''${!outputLib}"
-          done
-      fi
-
-      # Remove `fixincl' to prevent a retained dependency on the
-      # previous gcc.
-      rm -rf $out/libexec/gcc/*/*/install-tools
-      rm -rf $out/lib/gcc/*/*/install-tools
-
-      # More dependencies with the previous gcc or some libs (gccbug stores the build command line)
-      rm -rf $out/bin/gccbug
-
-      # Remove .la files, they're not adjusted for the makeCompatibilitySymlink magic,
-      # which confuses libtool and leads to weird linking errors.
-      # Removing the files just makes libtool link .so files directly, which is usually
-      # what we want anyway.
-      find $out -name '*.la' -delete
-
-      if type "install_name_tool"; then
-          for i in "''${!outputLib}"/lib/*.*.dylib "''${!outputLib}"/lib/*.so.[0-9]; do
-              install_name_tool -id "$i" "$i" || true
-              for old_path in $(otool -L "$i" | grep "$out" | awk '{print $1}'); do
-                new_path=`echo "$old_path" | sed "s,$out,''${!outputLib},"`
-                install_name_tool -change "$old_path" "$new_path" "$i" || true
-              done
-          done
-      fi
-
-      # Get rid of some "fixed" header files
-      rm -rfv $out/lib/gcc/*/*/include-fixed/{root,linux,sys/mount.h,bits/statx.h,pthread.h}
-
-      # Replace hard links for i686-pc-linux-gnu-gcc etc. with symlinks.
-      for i in $out/bin/*-gcc*; do
-          if cmp -s $out/bin/gcc $i; then
-              ln -sfn gcc $i
+    postInstall =
+      # SH installs libraries into a multilib subdirectory (e.g. lib/!m4/)
+      # even with --disable-multilib; move them to the expected location.
+      lib.optionalString stdenv.targetPlatform.isSh4 ''
+        for _mdir in $out/''${targetConfig+$targetConfig/}lib/!*/; do
+          if [ -d "$_mdir" ]; then
+            mv "$_mdir"/* $out/''${targetConfig+$targetConfig/}lib/
+            rmdir "$_mdir"
           fi
-      done
+        done
+      ''
+      + ''
+        # Clean up our compatibility symlinks (see above)
+        for link in "''${compatibilitySymlinks[@]}"; do
+          echo "Removing compatibility symlink: $link"
+          rm -f "$link"
+        done
 
-      for i in $out/bin/c++ $out/bin/*-c++* $out/bin/*-g++*; do
-          if cmp -s $out/bin/g++ $i; then
-              ln -sfn g++ $i
-          fi
-      done
+        # Move target runtime libraries to lib output.
+        # For non-cross, they're in $out/lib; for cross, they're in $out/$targetConfig/lib.
+        targetLibDir="''${targetConfig+$targetConfig/}lib"
 
-      # Two identical man pages are shipped (moving and compressing is done later)
-      for i in "$out"/share/man/man1/*g++.1; do
-          if test -e "$i"; then
-              man_prefix=`echo "$i" | sed "s,.*/\(.*\)g++.1,\1,"`
-              ln -sf "$man_prefix"gcc.1 "$i"
-          fi
-      done
-    ''
-    + lib.optionalString stdenv.targetPlatform.isCygwin ''
-      targetBinDir="''${targetConfig+$targetConfig/}bin"
-      for i in "''${!outputBin}/$targetLibDir"/cyg*.dll; do
-        mkdir -p "''${!outputLib}/$targetBinDir"
-        mv "$i" "''${!outputLib}/$targetBinDir"/
-      done
-    ''
-    # if cross-compiling, link from $lib/lib to $lib/${targetConfig}.
-    # since native-compiles have $lib/lib as a directory (not a
-    # symlink), this ensures that in every case we can assume that
-    # $lib/lib contains the .so files
-    + lib.optionalString isCross ''
-      if [ -e "$lib/$targetConfig/lib" ]; then
-        ln -s "$lib/$targetConfig/lib" "$lib/lib"
-      fi
-    '';
+        moveToOutput "$targetLibDir/lib*.so*" "''${!outputLib}"
+        moveToOutput "$targetLibDir/lib*.dylib" "''${!outputLib}"
+        moveToOutput "$targetLibDir/lib*.dll.a" "''${!outputLib}"
+        moveToOutput "$targetLibDir/lib*.dll" "''${!outputLib}"
+        moveToOutput "share/gcc-*/python" "''${!outputLib}"
+
+        if [ -z "$enableShared" ]; then
+            moveToOutput "$targetLibDir/lib*.a" "''${!outputLib}"
+        fi
+
+        for i in "''${!outputLib}"/$targetLibDir/*.py; do
+            substituteInPlace "$i" --replace "$out" "''${!outputLib}"
+        done
+
+        # Multilib and cross can't exist at the same time, so just use lib64 here
+        if [ -n "$enableMultilib" ]; then
+            moveToOutput "lib64/lib*.so*" "''${!outputLib}"
+            moveToOutput "lib64/lib*.dylib" "''${!outputLib}"
+            moveToOutput "lib64/lib*.dll.a" "''${!outputLib}"
+            moveToOutput "lib64/lib*.dll" "''${!outputLib}"
+
+            for i in "''${!outputLib}"/lib64/*.py; do
+                substituteInPlace "$i" --replace "$out" "''${!outputLib}"
+            done
+        fi
+
+        # Remove `fixincl' to prevent a retained dependency on the
+        # previous gcc.
+        rm -rf $out/libexec/gcc/*/*/install-tools
+        rm -rf $out/lib/gcc/*/*/install-tools
+
+        # More dependencies with the previous gcc or some libs (gccbug stores the build command line)
+        rm -rf $out/bin/gccbug
+
+        # Remove .la files, they're not adjusted for the makeCompatibilitySymlink magic,
+        # which confuses libtool and leads to weird linking errors.
+        # Removing the files just makes libtool link .so files directly, which is usually
+        # what we want anyway.
+        find $out -name '*.la' -delete
+
+        if type "install_name_tool"; then
+            for i in "''${!outputLib}"/lib/*.*.dylib "''${!outputLib}"/lib/*.so.[0-9]; do
+                install_name_tool -id "$i" "$i" || true
+                for old_path in $(otool -L "$i" | grep "$out" | awk '{print $1}'); do
+                  new_path=`echo "$old_path" | sed "s,$out,''${!outputLib},"`
+                  install_name_tool -change "$old_path" "$new_path" "$i" || true
+                done
+            done
+        fi
+
+        # Get rid of some "fixed" header files
+        rm -rfv $out/lib/gcc/*/*/include-fixed/{root,linux,sys/mount.h,bits/statx.h,pthread.h}
+
+        # Replace hard links for i686-pc-linux-gnu-gcc etc. with symlinks.
+        for i in $out/bin/*-gcc*; do
+            if cmp -s $out/bin/gcc $i; then
+                ln -sfn gcc $i
+            fi
+        done
+
+        for i in $out/bin/c++ $out/bin/*-c++* $out/bin/*-g++*; do
+            if cmp -s $out/bin/g++ $i; then
+                ln -sfn g++ $i
+            fi
+        done
+
+        # Two identical man pages are shipped (moving and compressing is done later)
+        for i in "$out"/share/man/man1/*g++.1; do
+            if test -e "$i"; then
+                man_prefix=`echo "$i" | sed "s,.*/\(.*\)g++.1,\1,"`
+                ln -sf "$man_prefix"gcc.1 "$i"
+            fi
+        done
+      ''
+      + lib.optionalString stdenv.targetPlatform.isCygwin ''
+        targetBinDir="''${targetConfig+$targetConfig/}bin"
+        for i in "''${!outputBin}/$targetLibDir"/cyg*.dll; do
+          mkdir -p "''${!outputLib}/$targetBinDir"
+          mv "$i" "''${!outputLib}/$targetBinDir"/
+        done
+      ''
+      # if cross-compiling, link from $lib/lib to $lib/${targetConfig}.
+      # since native-compiles have $lib/lib as a directory (not a
+      # symlink), this ensures that in every case we can assume that
+      # $lib/lib contains the .so files
+      + lib.optionalString isCross ''
+        if [ -e "$lib/$targetConfig/lib" ]; then
+          ln -s "$lib/$targetConfig/lib" "$lib/lib"
+        fi
+      '';
   }
 ))

--- a/pkgs/development/compilers/gcc/common/checksum.nix
+++ b/pkgs/development/compilers/gcc/common/checksum.nix
@@ -5,17 +5,12 @@
   langC,
   langCC,
   runtimeShell,
+  buildIsHost,
+  hostIsTarget,
 }:
 
 let
-  enableChecksum =
-    (
-      with stdenv;
-      lib.systems.equals buildPlatform hostPlatform && lib.systems.equals hostPlatform targetPlatform
-    )
-    && langC
-    && langCC
-    && !stdenv.hostPlatform.isDarwin;
+  enableChecksum = buildIsHost && hostIsTarget && langC && langCC && !stdenv.hostPlatform.isDarwin;
 in
 (
   pkg:

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -32,7 +32,8 @@
   langObjCpp,
   langJit,
   langRust ? false,
-  disableBootstrap ? (!lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform),
+  hostIsTarget,
+  disableBootstrap ? (!hostIsTarget),
 }:
 
 assert !enablePlugin -> disableGdbPlugin;
@@ -48,7 +49,6 @@ assert !enablePlugin -> disableGdbPlugin;
 
 let
   inherit (stdenv)
-    buildPlatform
     hostPlatform
     targetPlatform
     ;
@@ -56,9 +56,8 @@ let
   # See https://github.com/NixOS/nixpkgs/pull/209870#issuecomment-1500550903
   disableBootstrap' = disableBootstrap && !langFortran && !langGo;
 
-  crossMingw = (!lib.systems.equals targetPlatform hostPlatform) && targetPlatform.isMinGW;
-  crossDarwin =
-    (!lib.systems.equals targetPlatform hostPlatform) && targetPlatform.libc == "libSystem";
+  crossMingw = !hostIsTarget && targetPlatform.isMinGW;
+  crossDarwin = !hostIsTarget && targetPlatform.libc == "libSystem";
 
   crossConfigureFlags =
     # Ensure that -print-prog-name is able to find the correct programs.
@@ -247,20 +246,18 @@ let
     ++ lib.optional (isl != null) "--with-isl=${isl}"
 
     # Ada options, gcc can't build the runtime library for a cross compiler
-    ++ lib.optional langAda (
-      if lib.systems.equals hostPlatform targetPlatform then "--enable-libada" else "--disable-libada"
-    )
+    ++ lib.optional langAda (if hostIsTarget then "--enable-libada" else "--disable-libada")
 
     ++ import ../common/platform-flags.nix {
       inherit (stdenv) targetPlatform;
       inherit lib;
     }
-    ++ lib.optionals (!lib.systems.equals targetPlatform hostPlatform) crossConfigureFlags
+    ++ lib.optionals (!hostIsTarget) crossConfigureFlags
     ++ lib.optional disableBootstrap' "--disable-bootstrap"
 
     # Platform-specific flags
     ++ lib.optional (
-      lib.systems.equals targetPlatform hostPlatform && targetPlatform.isx86_32
+      hostIsTarget && targetPlatform.isx86_32
     ) "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
     ++ lib.optional (targetPlatform.isNetBSD || targetPlatform.isCygwin) "--disable-libssp" # Provided by libc.
     ++ lib.optionals hostPlatform.isSunOS [
@@ -277,7 +274,7 @@ let
       lib.optional (targetPlatform.libc == "musl")
         # musl at least, disable: https://git.buildroot.net/buildroot/commit/?id=873d4019f7fb00f6a80592224236b3ba7d657865
         "--disable-libmpx"
-    ++ lib.optionals (lib.systems.equals targetPlatform hostPlatform && targetPlatform.libc == "musl") [
+    ++ lib.optionals (hostIsTarget && targetPlatform.libc == "musl") [
       "--disable-libsanitizer"
       "--disable-symvers"
       "libat_cv_have_ifunc=no"

--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -227,6 +227,9 @@ let
         ]
       else
         [ "--disable-multilib" ]
+        # SH targets need m4 and m4-nofpu variants (the kernel uses -m4-nofpu).
+        # An empty list disables -m4-nofpu entirely.
+        ++ lib.optional targetPlatform.isSh4 "--with-multilib-list=m4,m4-nofpu"
     )
     ++ lib.optional (!enableShared) "--disable-shared"
     ++ lib.singleton (lib.enableFeature enablePlugin "plugin")

--- a/pkgs/development/compilers/gcc/common/dependencies.nix
+++ b/pkgs/development/compilers/gcc/common/dependencies.nix
@@ -27,11 +27,13 @@
   cargo,
   withoutTargetLibc ? null,
   threadsCross ? null,
+  buildIsHost,
+  hostIsTarget,
 }:
 
 let
   inherit (lib) optionals;
-  inherit (stdenv) buildPlatform hostPlatform targetPlatform;
+  inherit (stdenv) buildPlatform targetPlatform;
 in
 
 {
@@ -56,12 +58,12 @@ in
   # same for all gcc's
   depsBuildTarget =
     (
-      if lib.systems.equals hostPlatform buildPlatform then
+      if buildIsHost then
         [
           targetPackages.stdenv.cc.bintools # newly-built gcc will be used
         ]
       else
-        assert lib.systems.equals targetPlatform hostPlatform;
+        assert hostIsTarget;
         [
           # build != host == target
           stdenv.cc

--- a/pkgs/development/compilers/gcc/common/extra-target-flags.nix
+++ b/pkgs/development/compilers/gcc/common/extra-target-flags.nix
@@ -4,11 +4,8 @@
   withoutTargetLibc,
   libcCross,
   threadsCross,
+  hostIsTarget,
 }:
-
-let
-  inherit (stdenv) hostPlatform targetPlatform;
-in
 
 {
   # For non-cross builds these flags are currently assigned in builder.sh.
@@ -18,7 +15,7 @@ in
     let
       mkFlags =
         dep:
-        lib.optionals ((!lib.systems.equals targetPlatform hostPlatform) && dep != null) (
+        lib.optionals (!hostIsTarget && dep != null) (
           [
             "-O2 -idirafter ${lib.getDev dep}${dep.incdir or "/include"}"
           ]
@@ -35,7 +32,7 @@ in
     let
       mkFlags =
         dep:
-        lib.optionals ((!lib.systems.equals targetPlatform hostPlatform) && dep != null) (
+        lib.optionals (!hostIsTarget && dep != null) (
           [
             "-Wl,-L${lib.getLib dep}${dep.libdir or "/lib"}"
           ]

--- a/pkgs/development/compilers/gcc/common/libgcc.nix
+++ b/pkgs/development/compilers/gcc/common/libgcc.nix
@@ -10,6 +10,7 @@
   hostPlatform,
   withoutTargetLibc,
   libcCross,
+  hostIsTarget,
 }:
 
 assert !stdenv.targetPlatform.hasSharedLibraries -> !enableShared;
@@ -24,19 +25,13 @@ lib.pipe drv
         pkg:
         pkg.overrideAttrs (
           previousAttrs:
-          lib.optionalAttrs
-            (
-              (!lib.systems.equals targetPlatform hostPlatform)
-              && (enableShared || targetPlatform.isMinGW)
-              && withoutTargetLibc
-            )
-            {
-              makeFlags = [
-                "all-gcc"
-                "all-target-libgcc"
-              ];
-              installTargets = "install-gcc install-target-libgcc";
-            }
+          lib.optionalAttrs (!hostIsTarget && (enableShared || targetPlatform.isMinGW) && withoutTargetLibc) {
+            makeFlags = [
+              "all-gcc"
+              "all-target-libgcc"
+            ];
+            installTargets = "install-gcc install-target-libgcc";
+          }
         )
       )
 
@@ -50,8 +45,7 @@ lib.pipe drv
 
         (
           let
-            targetPlatformSlash =
-              if lib.systems.equals hostPlatform targetPlatform then "" else "${targetPlatform.config}/";
+            targetPlatformSlash = if hostIsTarget then "" else "${targetPlatform.config}/";
 
             # If we are building a cross-compiler and the target libc provided
             # to us at build time has a libgcc, use that instead of building a

--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -29,8 +29,6 @@ in
   platforms = platforms.unix;
   teams = [
     teams.gcc
-  ]
-  ++ lib.optionals (teams ? security-review) [
     teams.security-review
   ];
   mainProgram = "${targetPrefix}gcc";

--- a/pkgs/development/compilers/gcc/common/pre-configure.nix
+++ b/pkgs/development/compilers/gcc/common/pre-configure.nix
@@ -14,6 +14,8 @@
   enableShared,
   enableMultilib,
   pkgsBuildTarget,
+  buildIsHost,
+  hostIsTarget,
 }:
 
 assert langAda -> gnat-bootstrap != null;
@@ -39,7 +41,7 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
       langFortran
       && (
 
-        (!lib.systems.equals buildPlatform hostPlatform) && (lib.systems.equals hostPlatform targetPlatform)
+        !buildIsHost && hostIsTarget
       )
     )
     ''
@@ -57,25 +59,18 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
 # HACK: if host and target config are the same, but the platforms are
 # actually different we need to convince the configure script that it
 # is in fact building a cross compiler although it doesn't believe it.
-+
-  lib.optionalString
-    (targetPlatform.config == hostPlatform.config && (!lib.systems.equals targetPlatform hostPlatform))
-    ''
-      substituteInPlace configure --replace is_cross_compiler=no is_cross_compiler=yes
-    ''
++ lib.optionalString (targetPlatform.config == hostPlatform.config && !hostIsTarget) ''
+  substituteInPlace configure --replace is_cross_compiler=no is_cross_compiler=yes
+''
 
 # Normally (for host != target case) --without-headers automatically
 # enables 'inhibit_libc=true' in gcc's gcc/configure.ac. But case of
 # gcc->clang or dynamic->static "cross"-compilation manages to evade it: there
-# ! lib.systems.equals hostPlatform targetPlatform, hostPlatform.config == targetPlatform.config.
+# ! hostIsTarget, hostPlatform.config == targetPlatform.config.
 # We explicitly inhibit libc headers use in this case as well.
 +
   lib.optionalString
-    (
-      (!lib.systems.equals targetPlatform hostPlatform)
-      && withoutTargetLibc
-      && targetPlatform.config == hostPlatform.config
-    )
+    (!hostIsTarget && withoutTargetLibc && targetPlatform.config == hostPlatform.config)
     ''
       export inhibit_libc=true
     ''
@@ -93,6 +88,6 @@ lib.optionalString (hostPlatform.isSunOS && hostPlatform.is64bit) ''
   done
 ''
 
-+ lib.optionalString (
-  (!lib.systems.equals targetPlatform hostPlatform) && withoutTargetLibc && enableShared
-) (import ./libgcc-buildstuff.nix { inherit lib stdenv; })
++ lib.optionalString (!hostIsTarget && withoutTargetLibc && enableShared) (
+  import ./libgcc-buildstuff.nix { inherit lib stdenv; }
+)

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -232,6 +232,8 @@ pipe
 
       inherit patches;
 
+      __structuredAttrs = true;
+
       outputs = [
         "out"
         "man"

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -66,9 +66,7 @@
 let
   inherit (lib)
     callPackageWith
-    filter
     getBin
-    maintainers
     makeLibraryPath
     makeSearchPathOutput
     mapAttrs
@@ -77,7 +75,6 @@ let
     optionals
     optionalString
     pipe
-    platforms
     versionAtLeast
     versions
     ;
@@ -453,7 +450,6 @@ pipe
           license
           description
           longDescription
-          platforms
           teams
           mainProgram
           identifiers

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -35,8 +35,14 @@
   zlib ? null,
   libucontext ? null,
   gnat-bootstrap ? null,
+  # Allows only computing system equality once across every file responsible for
+  # building gcc. Not part of the public API
+  _systemInfo ? {
+    buildIsHost = lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform;
+    hostIsTarget = lib.systems.equals stdenv.hostPlatform stdenv.targetPlatform;
+  },
   enableMultilib ? false,
-  enablePlugin ? (lib.systems.equals stdenv.hostPlatform stdenv.buildPlatform), # Whether to support user-supplied plug-ins
+  enablePlugin ? _systemInfo.buildIsHost, # Whether to support user-supplied plug-ins
   name ? "gcc",
   libcCross ? null,
   threadsCross ? { }, # for MinGW
@@ -76,6 +82,8 @@ let
     versions
     ;
 
+  inherit (_systemInfo) buildIsHost hostIsTarget;
+
   gccVersions = import ./versions.nix;
   version = gccVersions.fromMajorMinor majorMinorVersion;
 
@@ -107,21 +115,16 @@ let
   disableBootstrap = atLeast11 && !stdenv.hostPlatform.isDarwin && (atLeast12 -> !profiledCompiler);
 
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
-  targetConfig =
-    if (!lib.systems.equals targetPlatform hostPlatform) then targetPlatform.config else null;
+  targetConfig = if (!hostIsTarget) then targetPlatform.config else null;
 
   patches = callFile ./patches { };
 
   # Cross-gcc settings (build == host != target)
-  crossMingw = (!lib.systems.equals targetPlatform hostPlatform) && targetPlatform.isMinGW;
+  crossMingw = (!hostIsTarget) && targetPlatform.isMinGW;
   stageNameAddon = optionalString withoutTargetLibc "-nolibc";
-  crossNameAddon = optionalString (
-    !lib.systems.equals targetPlatform hostPlatform
-  ) "${targetPlatform.config}${stageNameAddon}-";
+  crossNameAddon = optionalString (!hostIsTarget) "${targetPlatform.config}${stageNameAddon}-";
 
-  targetPrefix = lib.optionalString (
-    !lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform
-  ) "${stdenv.targetPlatform.config}-";
+  targetPrefix = lib.optionalString (!hostIsTarget) "${stdenv.targetPlatform.config}-";
 
   callFile = callPackageWith {
     # lets
@@ -193,6 +196,8 @@ let
       which
       zlib
       ;
+
+    inherit buildIsHost hostIsTarget;
   };
 
 in
@@ -279,7 +284,7 @@ pipe
         substituteInPlace libgfortran/configure \
           --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
       ''
-      + (optionalString ((!lib.systems.equals targetPlatform hostPlatform) || stdenv.cc.libc != null)
+      + (optionalString ((!hostIsTarget) || stdenv.cc.libc != null)
         # On NixOS, use the right path to the dynamic linker instead of
         # `/lib/ld*.so'.
         (
@@ -352,16 +357,12 @@ pipe
           let
             target =
               optionalString (profiledCompiler) "profiled"
-              + optionalString (
-                (lib.systems.equals targetPlatform hostPlatform)
-                && (lib.systems.equals hostPlatform buildPlatform)
-                && !disableBootstrap
-              ) "bootstrap";
+              + optionalString (hostIsTarget && buildIsHost && !disableBootstrap) "bootstrap";
           in
           optional (target != "") target
         else
           optional (
-            (lib.systems.equals targetPlatform hostPlatform) && (lib.systems.equals hostPlatform buildPlatform)
+            hostIsTarget && buildIsHost
           ) (if profiledCompiler then "profiledbootstrap" else "bootstrap");
 
       inherit (callFile ./common/strip-attributes.nix { })
@@ -391,13 +392,11 @@ pipe
           # compiler (after the specs for the cross-gcc are created). Having
           # LIBRARY_PATH= makes gcc read the specs from ., and the build breaks.
 
-          CPATH = optionals (lib.systems.equals targetPlatform hostPlatform) (
+          CPATH = optionals hostIsTarget (
             makeSearchPathOutput "dev" "include" ([ ] ++ optional (zlib != null) zlib)
           );
 
-          LIBRARY_PATH = optionals (lib.systems.equals targetPlatform hostPlatform) (
-            makeLibraryPath (optional (zlib != null) zlib)
-          );
+          LIBRARY_PATH = optionals hostIsTarget (makeLibraryPath (optional (zlib != null) zlib));
 
           NIX_LDFLAGS = optionalString hostPlatform.isSunOS "-lm";
 
@@ -407,7 +406,7 @@ pipe
             ;
         }
         //
-          optionalAttrs (!atLeast12 && stdenv.cc.isClang && (!lib.systems.equals targetPlatform hostPlatform))
+          optionalAttrs (!atLeast12 && stdenv.cc.isClang && (!hostIsTarget))
             {
               NIX_CFLAGS_COMPILE = "-Wno-register";
             }
@@ -465,7 +464,7 @@ pipe
       }
       // optionalAttrs is10 {
         badPlatforms =
-          if (!lib.systems.equals targetPlatform hostPlatform) then [ "aarch64-darwin" ] else [ ];
+          if (!hostIsTarget) then [ "aarch64-darwin" ] else [ ];
       };
     }
     // optionalAttrs (!atLeast10 && stdenv.targetPlatform.isDarwin) {
@@ -488,6 +487,7 @@ pipe
           langJit
           targetPlatform
           hostPlatform
+          hostIsTarget
           withoutTargetLibc
           enableShared
           libcCross
@@ -495,6 +495,13 @@ pipe
       })
     ]
     ++ optionals atLeast11 [
-      (callPackage ./common/checksum.nix { inherit langC langCC; })
+      (callPackage ./common/checksum.nix {
+        inherit
+          langC
+          langCC
+          buildIsHost
+          hostIsTarget
+          ;
+      })
     ]
   )

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -77,6 +77,16 @@ in
   ]
   ++ (
     {
+      "16" = [
+        # Do not try looking for binaries and libraries in /lib and /usr/lib
+        ./13/no-sys-dirs-riscv.patch
+        # Mangle the nix store hash in __FILE__ to prevent unneeded runtime references
+        #
+        # TODO: Remove these and the `useMacroPrefixMap` conditional
+        # in `cc-wrapper` once <https://gcc.gnu.org/PR111527>
+        # is fixed.
+        ./13/mangle-NIX_STORE-in-__FILE__.patch
+      ];
       "15" = [
         # Do not try looking for binaries and libraries in /lib and /usr/lib
         ./13/no-sys-dirs-riscv.patch

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -23,6 +23,8 @@
   fetchurl,
   withoutTargetLibc,
   threadsCross,
+  buildIsHost,
+  hostIsTarget,
 }:
 
 let
@@ -44,10 +46,7 @@ let
   # aarch64-darwin, as it breaks building a foreign one:
   # https://github.com/iains/gcc-12-branch/issues/18
   canApplyIainsDarwinPatches =
-    stdenv.hostPlatform.isDarwin
-    && stdenv.hostPlatform.isAarch64
-    && (lib.systems.equals buildPlatform hostPlatform)
-    && (lib.systems.equals hostPlatform targetPlatform);
+    stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 && buildIsHost && hostIsTarget;
 
   inherit (lib) optionals optional;
 in
@@ -70,7 +69,7 @@ in
   hash = "sha256-bnHKJP5jR8rNJjRTi58/N/qZ5fPkuFBk7WblJWQpKOs=";
 })
 # Pass the path to a C++ compiler directly in the Makefile.in
-++ optional (!lib.systems.equals targetPlatform hostPlatform) ./libstdc++-target.patch
+++ optional (!hostIsTarget) ./libstdc++-target.patch
 ++ optionals (noSysDirs) (
   [
     # Do not try looking for binaries and libraries in /lib and /usr/lib

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -319,6 +319,7 @@ in
     hash = "sha256-8I2G4430gkYoWgUued4unqhk8ZCajHf1dcivAeuLZ0E=";
   })
 ]
+++ optional (targetPlatform.isMusl && targetPlatform.isx86_32) ./libssp-noshared-musl32.patch
 
 ## Windows
 

--- a/pkgs/development/compilers/gcc/patches/libssp-noshared-musl32.patch
+++ b/pkgs/development/compilers/gcc/patches/libssp-noshared-musl32.patch
@@ -1,0 +1,31 @@
+From c557286adc46536fe033df400c50a880b672cfd6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Timo=20Ter=C3=A4s?= <timo.teras@iki.fi>
+Date: Fri, 21 Aug 2020 07:03:00 +0000
+Subject: [PATCH] Alpine musl package provides libssp_nonshared.a. We link to
+ it unconditionally, as otherwise we get link failures if some objects are
+ -fstack-protector built and final link happens with -fno-stack-protector.
+ This seems to be the common case when bootstrapping gcc, the piepatches do
+ not seem to fully fix the crosstoolchain and bootstrap sequence wrt.
+ stack-protector flag usage.
+
+---
+ gcc/gcc.cc | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index 7b0d3d2743b..e46e976a2e8 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -1017,8 +1017,7 @@ proper position among the other output files.  */
+ 
+ #ifndef LINK_SSP_SPEC
+ #ifdef TARGET_LIBC_PROVIDES_SSP
+-#define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all" \
+-		       "|fstack-protector-strong|fstack-protector-explicit:}"
++#define LINK_SSP_SPEC "-lssp_nonshared"
+ #else
+ #define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all" \
+ 		       "|fstack-protector-strong|fstack-protector-explicit" \
+-- 
+2.50.1
+

--- a/pkgs/development/compilers/gcc/versions.nix
+++ b/pkgs/development/compilers/gcc/versions.nix
@@ -1,5 +1,6 @@
 let
   majorMinorToVersionMap = {
+    "16" = "16.1.0";
     "15" = "15.2.0";
     "14" = "14.3.0";
     "13" = "13.4.0";
@@ -17,6 +18,7 @@ let
     {
       # 3 digits: releases (14.2.0)
       # 4 digits: snapshots (14.2.1.20250322)
+      "16.1.0" = "sha256-UO+02Uwzl6/zsNYaWr10i03THZ0/Kre+BbFx02pRD3k=";
       "15.2.0" = "sha256-Q4/ZloJrDIJIWinaA6ctcdbjVBqD7HAt9Ccfb+Al0k4=";
       "14.3.0" = "sha256-4Nx3KXYlYxrI5Q+pL//v6Jmk63AlktpcMu8E4ik6yjo=";
       "13.4.0" = "sha256-nEzm27BAVo/cVFWIrAPFy8lajb8MeqSQFwhDr7WcqPU=";


### PR DESCRIPTION
This PR applies the series of git am patches from the previous 25.11-based cuda-legacy pin up through the current NixOS 26.05 release. This patch series was applied pre-branchoff, so it should be possible to follow either the 26.05 stable branch or the rolling unstable branch afterwards. Recommend merging along with (octopus) or after https://github.com/nixos-cuda/cuda-legacy/pull/9, as that PR fixes up the existing patchset to be exhaustive over all the GCC versions maintained in cuda-legacy.