### PR TITLE
Update pins corresponding to 26.05

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ We generally use commits from the latest stable release branch; the overlay shou
 Currently, that is (always be sure to verify as the README is not kept in sync):
 
 ```nix
-# nixos-25.11 2026-03-24
-nixpkgs = getFlake "github:NixOS/nixpkgs/1073dad219cb244572b74da2b20c7fe39cb3fa9e";
+# nixos-26.05-pre 2026-05-21
+nixpkgs = getFlake "github:NixOS/nixpkgs/32ff23b7ead295ae5cca5d731ff87ecce73eee44";
 ```
 
 # License

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,8 @@
       inputs =
         let
           defaults = {
-            # nixos-25.11 2026-03-24
-            nixpkgs = getFlake "github:NixOS/nixpkgs/1073dad219cb244572b74da2b20c7fe39cb3fa9e";
+            # nixos-26.05-pre 2026-05-21
+            nixpkgs = getFlake "github:NixOS/nixpkgs/32ff23b7ead295ae5cca5d731ff87ecce73eee44";
             # main 2026-03-01
             flake-parts = getFlake "github:hercules-ci/flake-parts/f20dc5d9b8027381c474144ecabc9034d6a839a3";
           };


### PR DESCRIPTION
Update pins to the baseline commit to which the patchset has been rolled forward, in https://github.com/nixos-cuda/cuda-legacy/pull/10. (Separate PR so that the backported `git am` patches are separate from manual changes.)

Currently marked as draft as this PR would not be valid to merge without my other PRs (https://github.com/nixos-cuda/cuda-legacy/pull/9, https://github.com/nixos-cuda/cuda-legacy/pull/10).

Conversely, merging those branches before this one would leave the pins invalid on the commit prior to this merge - so my local working reference I'm using for 26.05 testing is an octopus merge of all three of these branches. I'll leave it up to you as to whether that's splitting hairs ;)